### PR TITLE
Remove duplicate footer from courses page

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -3,7 +3,6 @@
 import { motion } from 'framer-motion';
 import { GraduationCap, Sparkles, Code, Server, Layers, Rocket, CheckCircle2, ArrowRight } from 'lucide-react';
 import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
 
 export default function CoursesPage() {
     return (
@@ -232,7 +231,6 @@ export default function CoursesPage() {
                     </div>
                 </div>
             </main>
-            <Footer />
         </div>
     );
 }


### PR DESCRIPTION
The courses page was rendering its own footer even though the shared app layout already adds the global footer. This removes the extra footer import and render from the courses page so the route shows the footer only once.