### PR TITLE
refactor(home): remove stray JSX and fix file structure in Hero component

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from 'next/dynamic';
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import Image from 'next/image';
@@ -12,17 +13,6 @@ import { MagneticText } from '../ui/magnetic-text';
 import LatestEventsHighlight from './LatestEventsHighlight';
 import InternshipCalendarCard from './InternshipCalendarCard';
 import CertificateCard from './CertificateCard';
-
-// ... (existing imports)
-
-// Inside Hero component return:
-{/* Featured Content Grid */ }
-<div className="w-full px-2 mt-12 grid grid-cols-1 lg:grid-cols-2 gap-4 relative z-10">
-    <LatestEventsHighlight className="w-full mt-0 mb-0" />
-    <InternshipCalendarCard />
-    <CertificateCard />
-</div>
-import dynamic from 'next/dynamic';
 
 const HeaderScene = dynamic(() => import('@/components/3d/HeaderScene'), { ssr: false });
 


### PR DESCRIPTION
Fixes #14  | GSSoC'26 | @devpathindcommunity-india

## What was wrong
`src/components/home/Hero.tsx` had stray code outside the component body:
- Two placeholder comments (lines 16, 18) left from a previous refactor
- A duplicate "Featured Content Grid" JSX block (lines 19–24) sitting outside the Hero function — identical markup already existed inside the component at lines 89–94
- The `dynamic` import from `next/dynamic` was misplaced at line 25, after the stray JSX block

## What was changed
- Deleted the duplicate stray JSX block (lines 19–24) — not moved, because the identical block already exists inside the component's return
- Deleted the stray placeholder comments (lines 16, 18)
- Moved `import dynamic from 'next/dynamic'` to the top of the import block where it belongs

**Only `src/components/home/Hero.tsx` was modified. 1 file, 1 insertion, 11 deletions.**

## Lint & Build note
`npm run lint` and `npm run build` were run. All errors found are pre-existing in other files 
(unrelated to this change). This PR introduces zero new lint errors.