### PR TITLE
feat: update official repository URLs and configure ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ Thumbs.db
 
 # Temp
 tmp/
+
+# Scripts & Config
+scripts/*.ps1
+.firebaserc

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -81,7 +81,7 @@ const jsonLd = {
   "sameAs": [
     "https://twitter.com/DevPath_Community",
     "https://www.linkedin.com/company/devpath-community",
-    "https://github.com/DevPath-Community-Website"
+    "https://github.com/devpathindcommunity-india/DevPath-Web"
   ],
   "description": "A community of 50,000+ developers accelerating their coding skills through structured paths and real projects."
 };

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -34,7 +34,7 @@ export const siteConfig = {
       languageColor: "bg-blue-500",
       stars: "120+",
       icon: "BookOpen" as const,
-      url: "https://github.com/Aditya948351/DevPath-Community-Website",
+      url: "https://github.com/devpathindcommunity-india/DevPath-Web",
       isPublic: true,
     },
     {


### PR DESCRIPTION
This PR corrects the GitHub repository links inside layout and site configurations to reference the official organization URL devpathindcommunity-india/DevPath-Web, and adds .gitignore exclusions for temporary .ps1 automation scripts and local Firebase settings.