### PR TITLE
feat(a11y): Full keyboard navigation and ARIA support for Navbar and NotificationDropdown

### DIFF
--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import { Bell } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import { useAuth } from "@/context/AuthContext"
@@ -21,6 +21,23 @@ export function NotificationDropdown() {
     const { user } = useAuth()
     const [isOpen, setIsOpen] = useState(false)
     const [notifications, setNotifications] = useState<Notification[]>([])
+    const triggerRef = useRef<HTMLButtonElement>(null)
+
+    const closePanel = useCallback(() => {
+        setIsOpen(false)
+        // Return focus to trigger when panel closes
+        triggerRef.current?.focus()
+    }, [])
+
+    // Close on Escape
+    useEffect(() => {
+        if (!isOpen) return
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') closePanel()
+        }
+        document.addEventListener('keydown', onKey)
+        return () => document.removeEventListener('keydown', onKey)
+    }, [isOpen, closePanel])
 
     useEffect(() => {
         if (!user) return;
@@ -82,12 +99,21 @@ export function NotificationDropdown() {
         <div className="relative">
             {/* Bell Button */}
             <button
+                ref={triggerRef}
+                id="notification-trigger"
                 onClick={() => setIsOpen(!isOpen)}
-                className="relative p-2 rounded-xl hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ''}`}
+                aria-expanded={isOpen}
+                aria-haspopup="true"
+                aria-controls="notification-panel"
+                className="relative p-2 rounded-xl hover:bg-black/5 dark:hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
             >
-                <Bell className="w-5 h-5 text-gray-700 dark:text-gray-200" />
+                <Bell className="w-5 h-5 text-gray-700 dark:text-gray-200" aria-hidden="true" />
                 {unreadCount > 0 && (
-                    <span className="absolute -top-1 -right-1 w-5 h-5 bg-gradient-to-r from-cyan-500 to-purple-500 rounded-full text-xs font-bold flex items-center justify-center animate-pulse text-white">
+                    <span
+                        className="absolute -top-1 -right-1 w-5 h-5 bg-gradient-to-r from-cyan-500 to-purple-500 rounded-full text-xs font-bold flex items-center justify-center animate-pulse text-white"
+                        aria-hidden="true"
+                    >
                         {unreadCount}
                     </span>
                 )}
@@ -100,23 +126,29 @@ export function NotificationDropdown() {
                         {/* Backdrop */}
                         <div
                             className="fixed inset-0 z-40"
-                            onClick={() => setIsOpen(false)}
+                            onClick={closePanel}
+                            aria-hidden="true"
                         />
 
                         {/* Notification Panel */}
                         <motion.div
+                            id="notification-panel"
                             initial={{ opacity: 0, y: 10, scale: 0.95 }}
                             animate={{ opacity: 1, y: 0, scale: 1 }}
                             exit={{ opacity: 0, y: 10, scale: 0.95 }}
                             className="absolute right-0 top-full mt-2 w-96 bg-white/95 dark:bg-[#0f1419]/95 backdrop-blur-xl border border-black/5 dark:border-white/10 rounded-2xl shadow-2xl z-50 max-h-[600px] overflow-hidden"
+                            role="region"
+                            aria-label="Notifications"
+                            aria-live="polite"
                         >
                             {/* Header */}
                             <div className="p-4 border-b border-black/5 dark:border-white/10 flex items-center justify-between">
-                                <h3 className="font-bold text-lg text-gray-900 dark:text-white">Notifications</h3>
+                                <h3 className="font-bold text-lg text-gray-900 dark:text-white" id="notification-heading">Notifications</h3>
                                 {unreadCount > 0 && (
                                     <button
                                         onClick={markAllAsRead}
-                                        className="text-xs text-cyan-600 dark:text-cyan-400 hover:text-cyan-500 dark:hover:text-cyan-300 transition-colors"
+                                        aria-label={`Mark all ${unreadCount} notifications as read`}
+                                        className="text-xs text-cyan-600 dark:text-cyan-400 hover:text-cyan-500 dark:hover:text-cyan-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded"
                                     >
                                         Mark all as read
                                     </button>
@@ -136,8 +168,17 @@ export function NotificationDropdown() {
                                             key={notif.id}
                                             initial={{ opacity: 0, x: -20 }}
                                             animate={{ opacity: 1, x: 0 }}
-                                            className={`p-4 border-b border-black/5 dark:border-white/5 hover:bg-black/5 dark:hover:bg-white/5 cursor-pointer transition-colors ${!notif.read ? 'bg-black/5 dark:bg-white/5' : ''}`}
+                                            className={`p-4 border-b border-black/5 dark:border-white/5 hover:bg-black/5 dark:hover:bg-white/5 cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-cyan-500 ${!notif.read ? 'bg-black/5 dark:bg-white/5' : ''}`}
                                             onClick={() => markAsRead(notif.id)}
+                                            role="button"
+                                            tabIndex={0}
+                                            aria-label={`${notif.title}: ${notif.message}${!notif.read ? ' (unread)' : ''}`}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter' || e.key === ' ') {
+                                                    e.preventDefault()
+                                                    markAsRead(notif.id)
+                                                }
+                                            }}
                                         >
                                             <div className="flex items-start gap-3">
                                                 {/* Type Icon */}
@@ -163,7 +204,7 @@ export function NotificationDropdown() {
 
                                                 {/* Unread Indicator */}
                                                 {!notif.read && (
-                                                    <div className="w-2 h-2 bg-cyan-500 rounded-full flex-shrink-0 mt-2" />
+                                                    <div className="w-2 h-2 bg-cyan-500 rounded-full flex-shrink-0 mt-2" aria-hidden="true" />
                                                 )}
                                             </div>
                                         </motion.div>
@@ -175,8 +216,9 @@ export function NotificationDropdown() {
                             <div className="p-3 border-t border-black/5 dark:border-white/10 text-center">
                                 <Link
                                     href="/notifications"
-                                    onClick={() => setIsOpen(false)}
-                                    className="text-sm text-cyan-600 dark:text-cyan-400 hover:text-cyan-500 dark:hover:text-cyan-300 transition-colors block w-full"
+                                    onClick={closePanel}
+                                    aria-label="View all notifications"
+                                    className="text-sm text-cyan-600 dark:text-cyan-400 hover:text-cyan-500 dark:hover:text-cyan-300 transition-colors block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 rounded"
                                 >
                                     View All Notifications
                                 </Link>

--- a/src/components/layout/Navbar.module.css
+++ b/src/components/layout/Navbar.module.css
@@ -66,6 +66,12 @@
     color: var(--text-primary);
     letter-spacing: -0.5px;
     text-decoration: none;
+    border-radius: 8px;
+}
+
+.logo:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 4px;
 }
 
 .logoIcon {
@@ -94,6 +100,13 @@
 }
 
 .navLink:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.navLink:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
     color: #fff;
     background: rgba(255, 255, 255, 0.1);
 }
@@ -129,6 +142,11 @@
     transform: scale(1.05);
 }
 
+.iconButton:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
+}
+
 .profileButton {
     display: flex;
     align-items: center;
@@ -150,6 +168,11 @@
     transform: translateY(-1px);
 }
 
+.profileButton:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
+}
+
 /* Hamburger Menu Button - Hidden on Desktop */
 .hamburger {
     display: none;
@@ -168,6 +191,11 @@
 
 .hamburger:hover {
     background: rgba(255, 255, 255, 0.1);
+}
+
+.hamburger:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
 }
 
 /* Mobile Menu Backdrop */
@@ -231,6 +259,11 @@
     color: var(--text-primary);
 }
 
+.mobileClose:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
+}
+
 .mobileNav {
     display: flex;
     flex-direction: column;
@@ -250,6 +283,13 @@
 
 .mobileLink:hover,
 .mobileLink:active {
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-primary);
+}
+
+.mobileLink:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
     background: rgba(255, 255, 255, 0.05);
     color: var(--text-primary);
 }
@@ -290,6 +330,11 @@
     background: rgba(255, 255, 255, 0.1);
 }
 
+.mobileProfileButton:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
+}
+
 .profileAvatar {
     display: flex;
     align-items: center;
@@ -310,6 +355,11 @@
 .profileAvatar:hover {
     background: #2563eb;
     transform: translateY(-1px);
+}
+
+.profileAvatar:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
 }
 
 /* Mobile Responsive Styles */

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -59,10 +59,10 @@ export default function Navbar() {
                 className={styles.navbarContainer}
                 style={{ top: isMaintenanceMode ? '70px' : '20px' }}
             >
-                <nav className={styles.navbar} style={{ pointerEvents: isMaintenanceMode ? 'none' : 'auto' }}>
-                    <Link href="/" className={styles.logo}>
+                <nav className={styles.navbar} style={{ pointerEvents: isMaintenanceMode ? 'none' : 'auto' }} aria-label="Main navigation">
+                    <Link href="/" className={styles.logo} aria-label="DevPath home">
                         <div className={styles.logoIcon}>
-                            <Image src={logo} alt="DevPath Logo" width={32} height={32} className="rounded-full" />
+                            <Image src={logo} alt="" width={32} height={32} className="rounded-full" aria-hidden="true" />
                         </div>
                         <span className={styles.logoText}>DevPath</span>
                     </Link>
@@ -74,11 +74,16 @@ export default function Navbar() {
                                 isMaintenanceMode ? (
                                     <span
                                         key={link.href}
+                                        role="link"
+                                        aria-disabled="true"
+                                        tabIndex={0}
                                         className={`${styles.navLink} text-muted-foreground cursor-not-allowed opacity-50 ${link.label === 'Courses' ? 'text-xs' : ''}`}
                                         style={{ fontSize: link.label === 'Courses' ? '0.75rem' : undefined }}
                                         title="Maintenance Mode Active"
+                                        aria-label={`${link.label} (unavailable – maintenance mode)`}
+                                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.preventDefault(); }}
                                     >
-                                        {link.label === 'Community' && <Lock size={12} className="inline mr-1" />}
+                                        {link.label === 'Community' && <Lock size={12} className="inline mr-1" aria-hidden="true" />}
                                         {link.label}
                                     </span>
                                 ) : (
@@ -87,6 +92,7 @@ export default function Navbar() {
                                         href={link.href}
                                         className={`${styles.navLink} ${link.label === 'Courses' ? 'text-xs' : ''}`}
                                         style={{ fontSize: link.label === 'Courses' ? '0.75rem' : undefined }}
+                                        aria-current={pathname === link.href ? 'page' : undefined}
                                     >
                                         {link.label}
                                     </Link>
@@ -104,9 +110,13 @@ export default function Navbar() {
 
                     <div className={styles.actions}>
                         {user && (
-                            <div className="flex items-center gap-1 px-3 py-1.5 bg-orange-500/10 text-orange-500 rounded-full border border-orange-500/20" title="Current Streak">
-                                <Flame size={16} fill="currentColor" />
-                                <span className="text-sm font-bold">{currentStreak}</span>
+                            <div
+                                className="flex items-center gap-1 px-3 py-1.5 bg-orange-500/10 text-orange-500 rounded-full border border-orange-500/20"
+                                title={`Current streak: ${currentStreak} days`}
+                                aria-label={`Current streak: ${currentStreak} days`}
+                            >
+                                <Flame size={16} fill="currentColor" aria-hidden="true" />
+                                <span className="text-sm font-bold" aria-hidden="true">{currentStreak}</span>
                             </div>
                         )}
                         <ThemeToggle />
@@ -153,10 +163,12 @@ export default function Navbar() {
                         <button
                             className={styles.hamburger}
                             onClick={toggleMobileMenu}
-                            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+                            aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
                             aria-expanded={mobileMenuOpen}
+                            aria-controls="mobile-nav-drawer"
+                            aria-haspopup="dialog"
                         >
-                            {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+                            {mobileMenuOpen ? <X size={24} aria-hidden="true" /> : <Menu size={24} aria-hidden="true" />}
                         </button>
                     </div>
                 </nav >
@@ -178,30 +190,36 @@ export default function Navbar() {
 
                             {/* Drawer */}
                             <motion.div
+                                id="mobile-nav-drawer"
                                 className={styles.mobileMenu}
                                 initial={{ x: '100%' }}
                                 animate={{ x: 0 }}
                                 exit={{ x: '100%' }}
                                 transition={{ type: 'tween', duration: 0.3 }}
+                                role="dialog"
+                                aria-modal="true"
+                                aria-label="Navigation menu"
                             >
                                 <div className={styles.mobileHeader}>
-                                    <span className={styles.mobileTitle}>Menu</span>
+                                    <span className={styles.mobileTitle} id="mobile-nav-title">Menu</span>
                                     <button
                                         className={styles.mobileClose}
                                         onClick={closeMobileMenu}
-                                        aria-label="Close menu"
+                                        aria-label="Close navigation menu"
                                     >
-                                        <X size={24} />
+                                        <X size={24} aria-hidden="true" />
                                     </button>
                                 </div>
 
-                                <nav className={styles.mobileNav}>
+                                <nav className={styles.mobileNav} aria-label="Mobile navigation">
                                     {navLinks.map((link) => (
                                         <Link
                                             key={link.href}
                                             href={isMaintenanceMode ? "#" : link.href}
                                             className={`${styles.mobileLink} ${isMaintenanceMode ? 'opacity-50 cursor-not-allowed pointer-events-none' : ''}`}
                                             onClick={isMaintenanceMode ? undefined : closeMobileMenu}
+                                            aria-current={!isMaintenanceMode && pathname === link.href ? 'page' : undefined}
+                                            aria-disabled={isMaintenanceMode ? 'true' : undefined}
                                         >
                                             {link.label}
                                         </Link>


### PR DESCRIPTION
#### 🎯 What this PR does
Implements WCAG 2.1 AA accessibility requirements across all Navbar and `NotificationDropdown` interactive elements, enabling **seamless keyboard-only navigation** and correct **screen-reader announcements** throughout.

---

#### 📋 Changes

**`Navbar.tsx`**
- `<nav>` gets `aria-label="Main navigation"` landmark
- Logo link gets `aria-label="DevPath home"`; decorative image marked `alt="" aria-hidden`
- Active nav link gets `aria-current="page"` (desktop & mobile)
- Maintenance-mode `<span>` items: `role="link"`, `aria-disabled="true"`, `tabIndex={0}`, descriptive `aria-label`, `onKeyDown` blocks ghost Enter/Space navigation
- Streak badge: `aria-label` announces full value; icon + number are `aria-hidden` to avoid double-reading
- Hamburger: `aria-controls="mobile-nav-drawer"`, `aria-haspopup="dialog"`, improved label
- Mobile drawer: `id`, `role="dialog"`, `aria-modal="true"`, `aria-label`
- Mobile nav: `aria-label="Mobile navigation"` landmark; links get `aria-current` + `aria-disabled`

**`NotificationDropdown.tsx`**
- Bell button: `aria-label` with unread count, `aria-expanded`, `aria-haspopup`, `aria-controls`
- **Escape key** closes panel and **returns focus** to the trigger button
- Backdrop `<div>`: `aria-hidden="true"`
- Panel: `role="region"`, `aria-label`, `aria-live="polite"`
- "Mark all as read": descriptive `aria-label` with count
- Each notification item: `role="button"`, `tabIndex={0}`, full `aria-label`, `onKeyDown` (Enter/Space)

**`Navbar.module.css`**
- `:focus-visible` rings (`outline: 2px solid #38bdf8`) added for every interactive class: `.logo`, `.navLink`, `.iconButton`, `.profileButton`, `.profileAvatar`, `.hamburger`, `.mobileClose`, `.mobileLink`, `.mobileProfileButton`
- Uses `outline` (not `box-shadow`) for **forced-colour / high-contrast mode** compatibility

---

#### ✅ Acceptance Criteria
- [x] Fully navigable with **Tab**, **Shift+Tab**, **Enter**, **Space**, **Escape**
- [x] Screen readers announce **expanded/collapsed** states on dropdowns
- [x] `aria-current="page"` tracks the **active route**
- [x] All focus states are **highly visible** (cyan `#38bdf8` ring)
- [x] `tsc --noEmit` → **0 errors**

---
### Issue - https://github.com/issues/assigned?issue=devpathindcommunity-india%7CDevPath-Web%7C41

### Request - @Aditya948351 
Could you please add the appropriate labels to this repository/PR, as they were missed on my previous pull request? Proper labeling helps with accurate contribution tracking and project categorization.  

I’d really appreciate it if the labels could be updated accordingly. Thank you for your time and support!