### PR TITLE
fix: improve mobile notification dropdown responsiveness

### DIFF
--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -96,7 +96,7 @@ export function NotificationDropdown() {
     }
 
     return (
-        <div className="relative">
+        <div className="sm:relative">
             {/* Bell Button */}
             <button
                 ref={triggerRef}
@@ -136,7 +136,7 @@ export function NotificationDropdown() {
                             initial={{ opacity: 0, y: 10, scale: 0.95 }}
                             animate={{ opacity: 1, y: 0, scale: 1 }}
                             exit={{ opacity: 0, y: 10, scale: 0.95 }}
-                            className="absolute right-0 top-full mt-2 w-96 bg-white/95 dark:bg-[#0f1419]/95 backdrop-blur-xl border border-black/5 dark:border-white/10 rounded-2xl shadow-2xl z-50 max-h-[600px] overflow-hidden"
+                            className="absolute left-0 right-0 sm:left-auto sm:right-0 top-full mt-4 sm:mt-2 w-auto sm:w-96 origin-top sm:origin-top-right bg-white/95 dark:bg-[#0f1419]/95 backdrop-blur-xl border border-black/5 dark:border-white/10 rounded-2xl shadow-2xl z-50 max-h-[600px] overflow-hidden"
                             role="region"
                             aria-label="Notifications"
                             aria-live="polite"


### PR DESCRIPTION
## Description
Currently the notification dropdown in mobile devices gets cut and is outside the screen which prevents proper interaction and able to view the complete notification 

Fixes #1 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
- [x] Local testing
- [x] Vercel Preview Deployment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact

Screenshots:
Before 

<img width="285" height="210" alt="image" src="https://github.com/user-attachments/assets/ecab9b53-2294-4d18-abe1-64aa583e0709" />

After 

<img width="295" height="226" alt="image" src="https://github.com/user-attachments/assets/cd171e9b-3208-4abe-9b27-ded2c4e219d5" />
