### PR TITLE
 fix: remove redundant double-write in `Rewards.tsx` badge sync

### DIFF
--- a/src/components/profile/Rewards.tsx
+++ b/src/components/profile/Rewards.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useAuth } from '@/context/AuthContext';
-import { CheckCircle, Gift, Lock } from 'lucide-react';
-import { doc, updateDoc, arrayUnion, writeBatch, increment, serverTimestamp, collection, getDocs } from 'firebase/firestore';
+import { CheckCircle } from 'lucide-react';
+import { doc, updateDoc, writeBatch, serverTimestamp, collection, getDocs } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { POINTS } from '@/lib/points';
 import { calculateUserPointsAndBadges } from '@/lib/point-calculation';
@@ -12,7 +12,7 @@ import { useState, useEffect, useRef } from 'react';
 let lastBadgeCheckTime = 0;
 
 export default function Rewards({ user: propUser, projectCount = 0 }: { user?: any, projectCount?: number }) {
-    const { user: authUser, updateUserProfile } = useAuth();
+    const { user: authUser } = useAuth();
 
     // Use propUser if provided (public view), otherwise authUser (private view)
     const user = propUser || authUser;
@@ -87,12 +87,8 @@ export default function Rewards({ user: propUser, projectCount = 0 }: { user?: a
                     });
 
                     await batch.commit();
-
-                    // Update local state
-                    await updateUserProfile({
-                        points: result.points,
-                        achievements: result.achievements
-                    });
+                    // Local React state is updated automatically via the
+                    // onSnapshot listener in AuthContext — no second write needed.
 
                     if (badgesChanged) {
                         const newCount = result.achievements.length - currentBadges.length;
@@ -112,7 +108,7 @@ export default function Rewards({ user: propUser, projectCount = 0 }: { user?: a
         };
 
         checkAndSync();
-    }, [user, isOwner, updateUserProfile]);
+    }, [user, isOwner]);
 
     if (!user) return null;
 


### PR DESCRIPTION

## Summary

Fixes a data-integrity bug in the `Rewards` component where user points and
achievements were written to Firestore **twice** in the same operation —
once via `writeBatch` and once via `updateUserProfile` — creating a race
condition that could silently overwrite a user's earned points.

---

## Problem

In `src/components/profile/Rewards.tsx`, the `checkAndSync()` function
runs a Firestore `writeBatch` to atomically update a user's `points`,
`achievements`, and the `leaderboard` document. Immediately after
`batch.commit()` resolved, it called `updateUserProfile()` a second time
with the same absolute `points` value:

```tsx
await batch.commit();

// ❌ REDUNDANT — writes the same data again with a non-atomic absolute value
await updateUserProfile({
    points: result.points,
    achievements: result.achievements
});
```

### Why this is a bug

| Scenario | Impact |
|---|---|
| User earns XP from another action (e.g. daily login) **between** `batch.commit()` resolving and `updateUserProfile()` executing | The second write **overwrites** those new points with a stale absolute value |
| User is logged in on two tabs simultaneously | The two tabs race; whichever `updateUserProfile` resolves last wins, silently discarding the other's changes |
| `onSnapshot` in `AuthContext` fires between the two writes | The UI flickers as it receives two consecutive state updates with slightly different values |

`updateUserProfile()` itself calls `setDoc(..., { merge: true })` with an
absolute `points: number`, **not** a Firestore `increment()`. This means
it is not idempotent and can clobber concurrent writes.

The batch write is already the correct, atomic path. `AuthContext`'s
`onSnapshot` listener automatically syncs local React state the moment
Firestore reflects the batch commit — a second explicit write is both
unnecessary and harmful.

---

## Fix

Remove the `updateUserProfile()` call that follows `batch.commit()`. The
`onSnapshot` listener in `AuthContext` handles all local state propagation.

Additionally:
- Removed `updateUserProfile` from the `useEffect` dependency array (it is
  no longer used inside `checkAndSync`), which also eliminates a potential
  infinite re-render loop caused by a new `updateUserProfile` function
  reference on every `AuthContext` render.
- Removed unused imports (`arrayUnion`, `increment` from `firebase/firestore`
  and `Gift`, `Lock` from `lucide-react`) that were only needed by the
  deleted code path.

---

## Files Changed

- `src/components/profile/Rewards.tsx`

---

## Diff

```diff
-import { CheckCircle, Gift, Lock } from 'lucide-react';
-import { doc, updateDoc, arrayUnion, writeBatch, increment, serverTimestamp, collection, getDocs } from 'firebase/firestore';
+import { CheckCircle } from 'lucide-react';
+import { doc, updateDoc, writeBatch, serverTimestamp, collection, getDocs } from 'firebase/firestore';

-    const { user: authUser, updateUserProfile } = useAuth();
+    const { user: authUser } = useAuth();

     await batch.commit();
-
-    // Update local state
-    await updateUserProfile({
-        points: result.points,
-        achievements: result.achievements
-    });
+    // Local React state is updated automatically via the
+    // onSnapshot listener in AuthContext — no second write needed.

-    }, [user, isOwner, updateUserProfile]);
+    }, [user, isOwner]);
```

---

## Testing

1. Log in as a member with existing points.
2. Trigger the badge sync (ensure `lastBadgeScan` is older than 24h in Firestore, or temporarily remove that guard).
3. **Before fix:** Open DevTools → Network → observe two separate Firestore PATCH requests for the same document within milliseconds.
4. **After fix:** Only one Firestore PATCH (from the batch). The `points`/`achievements` fields update correctly in the UI within ~1–2 seconds via the `onSnapshot` listener.
5. Verify that XP earned from daily login is **not** overwritten after the badge sync completes.

---

## Issue - #94 