### PR TITLE
fix: stop badge sync from overwriting transactional XP

### DIFF
--- a/src/components/profile/Rewards.tsx
+++ b/src/components/profile/Rewards.tsx
@@ -2,10 +2,9 @@
 
 import { useAuth } from '@/context/AuthContext';
 import { CheckCircle } from 'lucide-react';
-import { doc, updateDoc, writeBatch, serverTimestamp, collection, getDocs } from 'firebase/firestore';
+import { doc, updateDoc, writeBatch, increment, serverTimestamp, collection, getDocs } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import { POINTS } from '@/lib/points';
-import { calculateUserPointsAndBadges } from '@/lib/point-calculation';
+import { determineBadges, getBadgeXp } from '@/lib/point-calculation';
 import { useState, useEffect, useRef } from 'react';
 
 // Global throttle to prevent infinite loops even if component remounts
@@ -30,80 +29,75 @@ export default function Rewards({ user: propUser, projectCount = 0 }: { user?: a
         if (Date.now() - lastBadgeCheckTime < 5000) return;
 
         const checkAndSync = async () => {
-            // Check lastBadgeScan from user data (24h throttle)
+            // 24-hour throttle from Firestore field
             const lastScan = user.lastBadgeScan || 0;
             if (Date.now() - lastScan < 24 * 60 * 60 * 1000) {
-                console.log("Point sync skipped (less than 24h since last scan).");
+                console.log('Badge sync skipped — less than 24 h since last scan.');
                 return;
             }
 
-            // Update global throttle
+            // Update in-memory throttle to prevent concurrent runs
             lastBadgeCheckTime = Date.now();
 
             try {
-                // 1. Fetch User Projects (needed for star count)
+                // 1. Fetch the user's projects (needed for builder-badge thresholds)
                 const projectsRef = collection(db, 'members', user.uid, 'projects');
                 const projectsSnap = await getDocs(projectsRef);
-                const userProjects = projectsSnap.docs.map(doc => doc.data());
+                const userProjects = projectsSnap.docs.map(d => d.data());
 
-                // 2. Calculate Expected Points & Badges
-                const result = calculateUserPointsAndBadges(user, userProjects);
+                // 2. Derive the full badge list the user has now earned
+                const earnedBadges = determineBadges(user, userProjects);
+                const currentBadges: string[] = user.achievements || [];
 
-                // 3. Compare with current state
-                const currentPoints = user.points || 0;
-                const currentBadges = user.achievements || [];
+                // 3. Identify ONLY newly unlocked badges — never revoke existing ones
+                const newBadges = earnedBadges.filter(id => !currentBadges.includes(id));
 
-                // Check if update needed (points mismatch OR badges mismatch)
-                const pointsChanged = result.points !== currentPoints;
-                const badgesChanged = JSON.stringify(result.achievements.sort()) !== JSON.stringify(currentBadges.sort());
-
-                if (pointsChanged || badgesChanged) {
-                    console.log("Syncing points/badges...", { old: currentPoints, new: result.points });
+                if (newBadges.length > 0) {
+                    // 4. Calculate XP for new badges only (additive, not a total reset)
+                    const newBadgeXp = newBadges.reduce((sum, id) => sum + getBadgeXp(id), 0);
+                    const updatedAchievements = [...currentBadges, ...newBadges];
 
                     const batch = writeBatch(db);
                     const userRef = doc(db, 'members', user.uid);
-                    const leaderboardRef = doc(db, 'leaderboard', user.uid);
 
-                    // Update Member
+                    // 5. Award badge XP as an increment — transactional points are preserved
                     batch.update(userRef, {
-                        points: result.points,
-                        achievements: result.achievements,
-                        lastBadgeScan: Date.now()
+                        achievements: updatedAchievements,
+                        lastBadgeScan: Date.now(),
+                        ...(newBadgeXp > 0 && { points: increment(newBadgeXp) }),
                     });
 
-                    // Update Leaderboard
-                    batch.set(leaderboardRef, { points: result.points }, { merge: true });
+                    // 6. Mirror XP increment on the leaderboard
+                    if (newBadgeXp > 0) {
+                        const leaderboardRef = doc(db, 'leaderboard', user.uid);
+                        batch.set(leaderboardRef, { points: increment(newBadgeXp) }, { merge: true });
+                    }
 
-                    // Update Badges Subcollection (Add missing ones)
-                    result.achievements.forEach(badgeId => {
-                        if (!currentBadges.includes(badgeId)) {
-                            const badgeRef = doc(db, 'members', user.uid, 'badges', badgeId);
-                            batch.set(badgeRef, {
-                                id: badgeId,
-                                earnedAt: serverTimestamp(),
-                                xpAwarded: POINTS.BADGE_EARNED // Approximate, as we recalc total
-                            });
-                        }
+                    // 7. Write individual badge documents for newly earned badges
+                    newBadges.forEach(badgeId => {
+                        const badgeRef = doc(db, 'members', user.uid, 'badges', badgeId);
+                        batch.set(badgeRef, {
+                            id: badgeId,
+                            earnedAt: serverTimestamp(),
+                            xpAwarded: getBadgeXp(badgeId),
+                        });
                     });
 
                     await batch.commit();
-                    // Local React state is updated automatically via the
-                    // onSnapshot listener in AuthContext — no second write needed.
+                    // AuthContext's onSnapshot propagates the update — no second write needed.
 
-                    if (badgesChanged) {
-                        const newCount = result.achievements.length - currentBadges.length;
-                        if (newCount > 0) alert(`🎉 You earned new badges and your points have been synchronized!`);
-                        else alert(`Your points have been synchronized.`);
-                    }
+                    const label = newBadges.length === 1 ? 'badge' : 'badges';
+                    alert(`🎉 You earned ${newBadges.length} new ${label} and ${newBadgeXp} XP!`);
+
                 } else {
-                    // Just update timestamp if nothing changed, to reset 24h timer
+                    // No new badges — just refresh the 24-hour scan timestamp
                     await updateDoc(doc(db, 'members', user.uid), {
-                        lastBadgeScan: Date.now()
+                        lastBadgeScan: Date.now(),
                     });
                 }
 
             } catch (error) {
-                console.error("Error syncing points:", error);
+                console.error('Error syncing badges:', error);
             }
         };
 

--- a/src/lib/point-calculation.ts
+++ b/src/lib/point-calculation.ts
@@ -16,94 +16,71 @@ export interface UserData {
     state?: string;
     followers?: string[];
     streak?: number;
-    achievements?: string[]; // Existing achievements
+    achievements?: string[];
 }
 
 export interface ProjectData {
-    stars?: string[]; // Array of user IDs who starred
+    stars?: string[];
 }
 
-export function calculateUserPointsAndBadges(user: UserData, projects: ProjectData[]) {
-    const newAchievements: string[] = [];
+/**
+ * Returns the XP value for a single badge.
+ * Social badges (GitHub, LinkedIn, Instagram) award more XP than standard badges.
+ */
+export function getBadgeXp(badgeId: string): number {
+    return SOCIAL_BADGES.includes(badgeId) ? POINTS.SOCIAL_BADGE_EARNED : POINTS.BADGE_EARNED;
+}
 
-    // --- 1. DETERMINE BADGES ---
+/**
+ * Determines which badges a user has earned based on their current profile
+ * and project data. Returns only the badge list — it does NOT calculate
+ * or return a point total, because total points include transactional XP
+ * (event participation, hackathon wins, daily logins, community follows)
+ * that cannot be derived from profile state alone.
+ *
+ * Callers should use Firestore `increment()` to award XP for newly unlocked
+ * badges rather than overwriting the user's total point value.
+ */
+export function determineBadges(user: UserData, projects: ProjectData[]): string[] {
+    const earned: string[] = [];
 
-    // Preserve Early Adopter if already exists (cannot be re-earned logically if it was time-limited)
+    // Early Adopter is time-limited — preserve if already held
     if (user.achievements?.includes('early-adopter')) {
-        newAchievements.push('early-adopter');
+        earned.push('early-adopter');
     }
 
-    // Profile Perfect
-    if (user.name && user.bio && user.photoURL && user.role) {
-        newAchievements.push('profile-perfect');
-    }
+    // Profile completeness
+    if (user.name && user.bio && user.photoURL && user.role) earned.push('profile-perfect');
+    if (user.bio && user.bio.length > 20) earned.push('storyteller');
+    if (user.photoURL) earned.push('face-of-community');
+    if (user.city || user.state) earned.push('local-hero');
 
-    // Connector (All 3)
-    if (user.github && user.linkedin && user.instagram) {
-        newAchievements.push('connector-social');
-    }
+    // Social links
+    if (user.github && user.linkedin && user.instagram) earned.push('connector-social');
+    if (user.github) earned.push('social-github');
+    if (user.linkedin) earned.push('social-linkedin');
+    if (user.instagram) earned.push('social-instagram');
 
-    // Social Badges
-    if (user.github) newAchievements.push('social-github');
-    if (user.linkedin) newAchievements.push('social-linkedin');
-    if (user.instagram) newAchievements.push('social-instagram');
-
-    // Basic Profile
-    if (user.bio && user.bio.length > 20) newAchievements.push('storyteller');
-    if (user.photoURL) newAchievements.push('face-of-community');
-    if (user.city || user.state) newAchievements.push('local-hero');
-
-    // Project Badges
+    // Projects
     const projectCount = projects.length;
-    if (projectCount >= 1) newAchievements.push('builder-1');
-    if (projectCount >= 3) newAchievements.push('builder-3');
-    if (projectCount >= 5) newAchievements.push('builder-5');
-    if (projectCount >= 10) newAchievements.push('builder-10');
+    if (projectCount >= 1)  earned.push('builder-1');
+    if (projectCount >= 3)  earned.push('builder-3');
+    if (projectCount >= 5)  earned.push('builder-5');
+    if (projectCount >= 10) earned.push('builder-10');
 
-    // Streak Badges
-    const streak = user.streak || 0;
-    if (streak >= 7) newAchievements.push('streak-7');
+    // Streak
+    if ((user.streak || 0) >= 7) earned.push('streak-7');
 
-    // --- 2. CALCULATE POINTS ---
+    return earned;
+}
 
-    // Badge Points
-    let badgePoints = 0;
-    newAchievements.forEach((badgeId: string) => {
-        if (SOCIAL_BADGES.includes(badgeId)) {
-            badgePoints += POINTS.SOCIAL_BADGE_EARNED;
-        } else {
-            badgePoints += POINTS.BADGE_EARNED;
-        }
-    });
-
-    // Follower Points
-    const followers = user.followers || [];
-    const followerPoints = followers.length * POINTS.FOLLOWER_GAINED;
-
-    // Project Points
-    let totalStars = 0;
-    projects.forEach(p => {
-        totalStars += (p.stars || []).length;
-    });
-    const projectPoints = (projectCount * 50) + (totalStars * POINTS.PROJECT_STAR);
-
-    // Streak Points
-    const streakPoints = streak * POINTS.STREAK_BONUS_PER_DAY;
-    const weeklyBonuses = Math.floor(streak / 7) * POINTS.WEEKLY_STREAK_BONUS;
-
-    const totalPoints = badgePoints + followerPoints + projectPoints + streakPoints + weeklyBonuses;
-
-    return {
-        points: totalPoints,
-        achievements: newAchievements,
-        stats: {
-            badgePoints,
-            followerPoints,
-            projectPoints,
-            streakPoints,
-            weeklyBonuses,
-            projectCount,
-            totalStars
-        }
-    };
+/**
+ * @deprecated Use `determineBadges` instead.
+ * This function returned an absolute `points` total that incorrectly
+ * overwrote transactional XP. Kept as a re-export shim so any remaining
+ * callers compile without changes while the migration is in progress.
+ */
+export function calculateUserPointsAndBadges(user: UserData, projects: ProjectData[]) {
+    const achievements = determineBadges(user, projects);
+    return { achievements, points: null };
 }


### PR DESCRIPTION

## Summary

Fixes a data-integrity bug where the 24-hour badge sync silently reset
every user's point total to a recalculated value that ignored all
transactional XP (event participation, hackathon wins, daily login
streaks, community follows). Users could lose hundreds or thousands of
points every day without any indication.

---

## Problem

### Root cause

`point-calculation.ts` exposed a function `calculateUserPointsAndBadges`
that attempted to derive a user's **total points** from first principles
by summing badge values, follower counts, project star counts, and streak
multipliers.

`Rewards.tsx` then used the result as an absolute point override:

```tsx
// ❌ Overwrites all transactional XP with a smaller recalculated floor
batch.update(userRef, {
    points: result.points,   // absolute number, NOT an increment
    achievements: result.achievements,
    lastBadgeScan: Date.now()
});
batch.set(leaderboardRef, { points: result.points }, { merge: true });
```

### What it silently discarded

The recalculated total **never included** XP from:

| Action | Points lost |
|---|---|
| `FOLLOW_COMMUNITY` | 500 pts (one-time) |
| `EVENT_PARTICIPATION` | 500 pts per event |
| `HACKATHON_WIN` | 5 000 pts per win |
| `DAILY_LOGIN` accumulation | 1–21+ pts/day |

A user who attended 3 events would silently lose **1 500 points** every
time the 24-hour sync ran.

---

## Fix

### `src/lib/point-calculation.ts`

- Removed the entire points-calculation block from `calculateUserPointsAndBadges`.
- Introduced `determineBadges(user, projects): string[]` — a focused
  function that **only** returns the badge list the user has earned. No
  point values, no absolute totals.
- Introduced `getBadgeXp(badgeId): number` — a pure helper that returns
  the correct XP for a single badge (social badges award 50 XP vs 20 XP
  for standard badges).
- Kept `calculateUserPointsAndBadges` as a `@deprecated` shim returning
  `{ achievements, points: null }` so any callers that haven't migrated
  yet compile without errors.

### `src/components/profile/Rewards.tsx`

- The sync effect now calls `determineBadges()` and compares the result
  against `user.achievements` to find **only newly unlocked badges**.
- XP is awarded per new badge via Firestore `increment()` — **additive,
  never a reset**.
- The `points` field is only touched if there are new badges. If no badges
  were unlocked, only `lastBadgeScan` is updated.
- Existing `achievements` are spread into the updated array so previously
  earned badges can never be removed by a sync run.
- The leaderboard is kept in sync using the same `increment()` pattern.

---

## Files Changed

| File | Change |
|---|---|
| `src/lib/point-calculation.ts` | Rewrote — removed absolute points calc, added `determineBadges` + `getBadgeXp` |
| `src/components/profile/Rewards.tsx` | Rewrote `checkAndSync` — badge-only diff, `increment()` for XP |

---

## Key Diff

### `point-calculation.ts`

```diff
-export function calculateUserPointsAndBadges(user, projects) {
-    // ... badge logic ...
-    // ❌ Calculates an absolute total that ignores transactional XP
-    const totalPoints = badgePoints + followerPoints + projectPoints + streakPoints;
-    return { points: totalPoints, achievements: newAchievements };
-}

+export function determineBadges(user, projects): string[] {
+    // Badge logic only — no points calculation
+    return earned;
+}
+
+export function getBadgeXp(badgeId: string): number {
+    return SOCIAL_BADGES.includes(badgeId) ? POINTS.SOCIAL_BADGE_EARNED : POINTS.BADGE_EARNED;
+}
+
+/** @deprecated — use determineBadges */
+export function calculateUserPointsAndBadges(user, projects) {
+    return { achievements: determineBadges(user, projects), points: null };
+}
```

### `Rewards.tsx`

```diff
-const result = calculateUserPointsAndBadges(user, userProjects);
-const pointsChanged = result.points !== currentPoints;
-const badgesChanged = ...;
-
-if (pointsChanged || badgesChanged) {
-    batch.update(userRef, {
-        points: result.points,        // ❌ absolute overwrite
-        achievements: result.achievements,
-    });
-}

+const earnedBadges = determineBadges(user, userProjects);
+const newBadges = earnedBadges.filter(id => !currentBadges.includes(id));
+
+if (newBadges.length > 0) {
+    const newBadgeXp = newBadges.reduce((sum, id) => sum + getBadgeXp(id), 0);
+    batch.update(userRef, {
+        achievements: [...currentBadges, ...newBadges],
+        ...(newBadgeXp > 0 && { points: increment(newBadgeXp) }),  // ✅ additive
+    });
+}
```

---

## Behaviour Before vs After

| Scenario | Before | After |
|---|---|---|
| User has 3 000 XP from events, 200 XP from badges | Sync runs → 200 pts written → **2 800 XP lost** | Sync runs → no new badges → only `lastBadgeScan` updated → **0 XP lost** |
| User earns first GitHub badge | Sync writes `points: 50` (absolute) → **resets all other XP** | Sync writes `points: increment(50)` → **adds 50 XP on top of existing total** |
| User earns 2 new badges | Alerts "points synchronized" even with no new badges | Alerts "🎉 You earned 2 new badges and 70 XP!" |

---

## Testing

1. Create a test user. Award them event XP manually via the admin panel
   (e.g. 1 000 pts).
2. Clear `lastBadgeScan` from their Firestore document to force the sync
   to run on next page load.
3. Load the profile page.
4. **Before fix:** `points` field resets to ~200 (badge floor only).
5. **After fix:** `points` field equals `1000 + new badge XP` — event XP
   is fully preserved.

---
### Issue No - #96