### PR TITLE
Fix: Closed Write Batch Reuse Crash in Recalculate Scripts (#101)

### DIFF
--- a/scripts/full-recalc.ts
+++ b/scripts/full-recalc.ts
@@ -51,7 +51,7 @@ async function fullRecalc() {
 
         const membersRef = collection(db, 'members');
         const snapshot = await getDocs(membersRef);
-        const batch = writeBatch(db);
+        let batch = writeBatch(db);
         let count = 0;
 
         console.log(`Found ${snapshot.size} members.`);
@@ -143,6 +143,7 @@ async function fullRecalc() {
             if (count % 400 === 0) {
                 await batch.commit();
                 console.log("Batch committed.");
+                batch = writeBatch(db);
             }
         }
 

--- a/scripts/recalculate-all-points.ts
+++ b/scripts/recalculate-all-points.ts
@@ -51,7 +51,7 @@ async function recalculatePoints() {
 
         const membersRef = collection(db, 'members');
         const snapshot = await getDocs(membersRef);
-        const batch = writeBatch(db);
+        let batch = writeBatch(db);
         let count = 0;
 
         console.log(`Found ${snapshot.size} members.`);
@@ -110,6 +110,7 @@ async function recalculatePoints() {
             if (count % 400 === 0) {
                 await batch.commit();
                 console.log("Batch committed.");
+                batch = writeBatch(db);
             }
         }
 


### PR DESCRIPTION
Closes #101. Declares write batch with let and re-initializes it on every batch commit to prevent crash on large databases.