### PR TITLE
# Fix Broken OSCG Sponsor Logo

### DIFF
--- a/src/components/home/Sponsors.tsx
+++ b/src/components/home/Sponsors.tsx
@@ -7,7 +7,7 @@ export default function Sponsors() {
     const communitySponsors = [
         {
             name: "OSCG",
-            logo: "https://osconnect.org/oscg-logo.png", // Fallback, normally they use an external URL like the others
+            logo: "https://raw.githubusercontent.com/YashKrTripathi/DevPath-Web/master/src/assets/oscg26.png",
             url: "https://osconnect.org/"
         },
         {

--- a/src/components/home/Sponsors.tsx
+++ b/src/components/home/Sponsors.tsx
@@ -7,7 +7,7 @@ export default function Sponsors() {
     const communitySponsors = [
         {
             name: "OSCG",
-            logo: "https://raw.githubusercontent.com/YashKrTripathi/DevPath-Web/master/src/assets/oscg26.png",
+            logo: "https://raw.githubusercontent.com/devpathindcommunity-india/DevPath-Web/master/src/assets/oscg26.png",
             url: "https://osconnect.org/"
         },
         {


### PR DESCRIPTION
Fixes #109

# Fix Broken OSCG Logo in Sponsors Section

## Summary

This PR fixes the broken OSCG logo in the homepage `Our Sponsors` section, specifically inside the `Trusted By` sponsor row.

The previous OSCG sponsor entry pointed to `https://osconnect.org/oscg-logo.png`, which no longer renders reliably. As a result, the sponsor card displayed fallback alt text instead of the official OSCG branding.

## Changes Made

- Updated the OSCG sponsor logo source in `src/components/home/Sponsors.tsx`.
- Replaced the broken `osconnect.org` image URL with the existing OSCG logo hosted in the upstream public repository.
- Used the upstream `master` repo raw asset URL: `https://raw.githubusercontent.com/devpathindcommunity-india/DevPath-Web/master/src/assets/oscg26.png`.
- Kept the sponsor-card styling, spacing, alignment, and hover behavior unchanged.
- Preserved the current `alt={sponsor.name}` behavior, so the image renders with `alt="OSCG"`.
- Added no new `.png`, `.jpg`, `.svg`, or other image files to the codebase.

## Styling Notes

No CSS changes were needed.

The existing sponsor card styles already provide consistent presentation with neighboring logos:

- `width: 280px`
- `height: 160px`
- centered flex alignment
- constrained image sizing via `.logo`
- existing grayscale and hover color treatment

Keeping the CSS untouched avoids visual drift from adjacent sponsor cards such as APERTRE 3.0 and Resourcio Community.

## Verification

- Confirmed the upstream OSCG image URL returns successfully.
- Confirmed the sponsor entry now uses a direct hosted URL.
- Ran a production build successfully with:

```bash
next build
```

Build completed successfully and all app routes were prerendered.

## Notes for Reviewers

The signed GitHub `private-user-images` URL shared for the logo was not committed because it contains an expiring token and would eventually break again.

This PR keeps the fix file-free by referencing the existing OSCG logo already present in the upstream public repository at `src/assets/oscg26.png` on the `master` branch. If a permanent Cloudinary-hosted OSCG logo becomes available later, the sponsor entry can be swapped directly to that URL.
