### PR TITLE
feat(wiki): implement client-side fuzzy search with keyword highlighting

### DIFF
--- a/src/app/wiki/Wiki.module.css
+++ b/src/app/wiki/Wiki.module.css
@@ -27,7 +27,7 @@
     background: var(--glass-highlight);
     border: 1px solid var(--glass-border);
     border-radius: 8px;
-    padding: 10px 16px 10px 40px;
+    padding: 10px 36px 10px 40px;
     color: var(--text-primary);
     font-size: 14px;
     outline: none;
@@ -45,6 +45,29 @@
     top: 50%;
     transform: translateY(-50%);
     color: var(--text-secondary);
+    pointer-events: none;
+}
+
+/* Clear (X) button inside the search input */
+.clearSearch {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition: color 0.15s;
+}
+
+.clearSearch:hover {
+    color: var(--text-primary);
 }
 
 .category {
@@ -197,4 +220,11 @@
         margin-left: 0;
         padding: 24px;
     }
+}
+
+.noResults {
+    color: var(--text-secondary);
+    font-size: 14px;
+    text-align: center;
+    padding: 24px 0;
 }

--- a/src/app/wiki/WikiSearchResults.module.css
+++ b/src/app/wiki/WikiSearchResults.module.css
@@ -1,0 +1,163 @@
+.wrapper {
+    padding: 8px 0;
+}
+
+.resultCount {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 16px;
+    padding: 0 4px;
+}
+
+.resultCount strong {
+    color: var(--text-primary);
+}
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.card {
+    width: 100%;
+    text-align: left;
+    background: var(--glass-highlight);
+    border: 1px solid var(--glass-border);
+    border-radius: 10px;
+    padding: 16px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.card::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: transparent;
+    transition: background 0.2s ease;
+}
+
+.card:hover {
+    border-color: rgba(0, 212, 255, 0.35);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 20px rgba(0, 212, 255, 0.08);
+}
+
+.card:hover::before {
+    background: #00d4ff;
+}
+
+.cardTop {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.category {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: #00d4ff;
+    font-weight: 600;
+}
+
+.arrow {
+    color: var(--text-secondary);
+    opacity: 0;
+    transform: translateX(-4px);
+    transition: all 0.2s ease;
+}
+
+.card:hover .arrow {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.cardTitle {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 6px;
+    line-height: 1.4;
+}
+
+.cardDesc {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 10px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.tags {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.tagIcon {
+    color: var(--text-secondary);
+    opacity: 0.6;
+    flex-shrink: 0;
+}
+
+.tag {
+    font-size: 11px;
+    background: rgba(0, 212, 255, 0.08);
+    border: 1px solid rgba(0, 212, 255, 0.18);
+    color: var(--text-secondary);
+    border-radius: 4px;
+    padding: 2px 7px;
+}
+
+/* The highlight mark */
+.highlight {
+    background: rgba(0, 212, 255, 0.22);
+    color: #00d4ff;
+    border-radius: 2px;
+    padding: 0 1px;
+    font-style: normal;
+}
+
+/* Empty state */
+.empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 16px;
+    gap: 10px;
+    text-align: center;
+}
+
+.emptyIcon {
+    color: var(--text-secondary);
+    opacity: 0.4;
+    margin-bottom: 4px;
+}
+
+.empty p {
+    font-size: 14px;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.empty strong {
+    color: #00d4ff;
+}
+
+.empty span {
+    font-size: 13px;
+    color: var(--text-secondary);
+}

--- a/src/app/wiki/WikiSearchResults.tsx
+++ b/src/app/wiki/WikiSearchResults.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React from "react";
+import { SearchResult, highlightText } from "@/utils/wikiSearch";
+import { FileText, Tag, ArrowRight } from "lucide-react";
+import styles from "./WikiSearchResults.module.css";
+
+type Props = {
+    results: SearchResult[];
+    query: string;
+    onSelect: (id: string) => void;
+};
+
+function Highlight({ text, query }: { text: string; query: string }) {
+    const parts = highlightText(text, query);
+    return (
+        <>
+            {parts.map((part, i) =>
+                part.highlight ? (
+                    <mark key={i} className={styles.highlight}>
+                        {part.text}
+                    </mark>
+                ) : (
+                    <span key={i}>{part.text}</span>
+                )
+            )}
+        </>
+    );
+}
+
+export default function WikiSearchResults({ results, query, onSelect }: Props) {
+    if (results.length === 0) {
+        return (
+            <div className={styles.empty}>
+                <FileText size={32} className={styles.emptyIcon} />
+                <p>No articles found for <strong>&ldquo;{query}&rdquo;</strong></p>
+                <span>Try different keywords or browse the sidebar.</span>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.wrapper}>
+            <p className={styles.resultCount}>
+                {results.length} article{results.length !== 1 ? "s" : ""} found for{" "}
+                <strong>&ldquo;{query}&rdquo;</strong>
+            </p>
+
+            <div className={styles.list}>
+                {results.map(result => (
+                    <button
+                        key={result.id}
+                        className={styles.card}
+                        onClick={() => onSelect(result.id)}
+                    >
+                        <div className={styles.cardTop}>
+                            <span className={styles.category}>{result.category}</span>
+                            <ArrowRight size={14} className={styles.arrow} />
+                        </div>
+
+                        <h3 className={styles.cardTitle}>
+                            <Highlight text={result.title} query={query} />
+                        </h3>
+
+                        <p className={styles.cardDesc}>
+                            <Highlight text={result.description} query={query} />
+                        </p>
+
+                        {result.keywordMatches.length > 0 && (
+                            <div className={styles.tags}>
+                                <Tag size={11} className={styles.tagIcon} />
+                                {result.keywordMatches.slice(0, 4).map(kw => (
+                                    <span key={kw} className={styles.tag}>
+                                        <Highlight text={kw} query={query} />
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useState, useEffect } from 'react';
-import { Search, ChevronRight, Book, Code, FileText, HelpCircle, ThumbsUp, ThumbsDown, Github, Users, MapPin, MessageCircle, Calendar } from 'lucide-react';
+import { useState, useEffect, useMemo } from 'react';
+import { Search, ChevronRight, Book, Code, FileText, HelpCircle, ThumbsUp, ThumbsDown, Github, Users, MapPin, MessageCircle, Calendar, X } from 'lucide-react';
 import Button from '@/components/ui/Button';
 import styles from './Wiki.module.css';
 
 import { wikiContent } from '@/data/wikiContent';
+import { wikiSearchIndex } from '@/data/wikiSearchIndex';
+import { searchArticles } from '@/utils/wikiSearch';
+import WikiSearchResults from './WikiSearchResults';
 
 const categories = [
     {
@@ -41,6 +44,30 @@ const categories = [
 export default function WikiPage() {
     const [activeArticle, setActiveArticle] = useState("intro");
     const [searchQuery, setSearchQuery] = useState("");
+
+    // Fuzzy search results (title + keywords + description)
+    const searchResults = useMemo(
+        () => searchArticles(wikiSearchIndex, searchQuery),
+        [searchQuery]
+    );
+
+    const isSearching = searchQuery.trim().length > 0;
+
+    // Sidebar nav: filter by title only when searching (lightweight)
+    const filteredCategories = isSearching
+        ? categories.map(category => ({
+            ...category,
+            items: category.items.filter(item =>
+                item.title.toLowerCase().includes(searchQuery.toLowerCase())
+            )
+        })).filter(category => category.items.length > 0)
+        : categories;
+
+    // When user clicks a search result, open that article and clear search
+    function handleResultSelect(id: string) {
+        setActiveArticle(id);
+        setSearchQuery("");
+    }
 
     useEffect(() => {
         const articleBody = document.querySelector(`.${styles.articleBody}`);
@@ -83,6 +110,7 @@ export default function WikiPage() {
     return (
         <div className={styles.container}>
             <aside className={styles.sidebar}>
+                {/* Search input */}
                 <div className={styles.searchContainer}>
                     <Search className={styles.searchIcon} size={16} />
                     <input
@@ -91,28 +119,51 @@ export default function WikiPage() {
                         className={styles.searchInput}
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
+                        aria-label="Search wiki articles"
                     />
+                    {isSearching && (
+                        <button
+                            className={styles.clearSearch}
+                            onClick={() => setSearchQuery("")}
+                            aria-label="Clear search"
+                        >
+                            <X size={14} />
+                        </button>
+                    )}
                 </div>
 
-                <nav>
-                    {categories.map((category, index) => (
-                        <div key={index} className={styles.category}>
-                            <h3 className={styles.categoryTitle}>{category.title}</h3>
-                            {category.items.map(item => (
-                                <div
-                                    key={item.id}
-                                    className={`${styles.navLink} ${activeArticle === item.id ? styles.active : ''}`}
-                                    onClick={() => setActiveArticle(item.id)}
-                                >
-                                    {item.icon}
-                                    {item.title}
-                                </div>
-                            ))}
-                        </div>
-                    ))}
-                </nav>
+                {/* Sidebar nav — hidden when search results are showing */}
+                {!isSearching && (
+                    <nav>
+                        {filteredCategories.map((category, index) => (
+                            <div key={index} className={styles.category}>
+                                <h3 className={styles.categoryTitle}>{category.title}</h3>
+                                {category.items.map(item => (
+                                    <div
+                                        key={item.id}
+                                        className={`${styles.navLink} ${activeArticle === item.id ? styles.active : ''}`}
+                                        onClick={() => setActiveArticle(item.id)}
+                                    >
+                                        {item.icon}
+                                        {item.title}
+                                    </div>
+                                ))}
+                            </div>
+                        ))}
+                    </nav>
+                )}
+
+                {/* Fuzzy search results in the sidebar */}
+                {isSearching && (
+                    <WikiSearchResults
+                        results={searchResults}
+                        query={searchQuery}
+                        onSelect={handleResultSelect}
+                    />
+                )}
             </aside>
 
+            {/* Main content — unchanged */}
             <main className={styles.content}>
                 <div className={styles.breadcrumb}>
                     <span>Docs</span>

--- a/src/data/wikiSearchIndex.ts
+++ b/src/data/wikiSearchIndex.ts
@@ -1,0 +1,99 @@
+import { SearchableArticle } from '@/utils/wikiSearch';
+
+/**
+ * Flat search index for all wiki articles.
+ * Add `description` and `keywords` here when you add new articles to wikiContent.tsx.
+ */
+export const wikiSearchIndex: SearchableArticle[] = [
+    {
+        id: "intro",
+        title: "Introduction to DevPath",
+        category: "Getting Started",
+        description: "Learn what DevPath is — a developer ecosystem for structured learning, real-world projects, XP, badges, and peer collaboration.",
+        keywords: ["devpath", "overview", "learning", "xp", "badges", "projects", "community", "ecosystem", "get started"],
+    },
+    {
+        id: "setup",
+        title: "Setting Up Your Profile",
+        category: "Getting Started",
+        description: "Complete your bio, link your GitHub account, and add your skills to get personalized project recommendations.",
+        keywords: ["profile", "bio", "github", "skills", "setup", "account", "onboarding"],
+    },
+    {
+        id: "xp",
+        title: "Understanding XP System",
+        category: "Getting Started",
+        description: "Earn XP through daily logins, completing projects, and merged pull requests. Gamify your learning journey.",
+        keywords: ["xp", "experience points", "gamification", "leaderboard", "rewards", "points", "login streak", "pull request"],
+    },
+    {
+        id: "react",
+        title: "Full Stack React Guide",
+        category: "Learning Paths",
+        description: "Master the MERN stack with React, Node.js, Express, MongoDB, Redux, and Zustand through a hands-on curriculum.",
+        keywords: ["react", "mern", "node", "express", "mongodb", "redux", "zustand", "full stack", "javascript", "frontend", "backend", "hooks"],
+    },
+    {
+        id: "python",
+        title: "Python for AI Roadmap",
+        category: "Learning Paths",
+        description: "Go from Python basics to building neural networks with NumPy, Pandas, Scikit-Learn, TensorFlow, and PyTorch.",
+        keywords: ["python", "ai", "machine learning", "deep learning", "numpy", "pandas", "scikit-learn", "tensorflow", "pytorch", "neural network", "roadmap"],
+    },
+    {
+        id: "community-offerings",
+        title: "What Community Offers",
+        category: "Community",
+        description: "Discover structured roadmaps, peer learning, career support, mock interviews, job referrals, and exclusive hackathon access.",
+        keywords: ["benefits", "career", "roadmap", "peer learning", "interview", "job", "referral", "hackathon", "webinar", "recognition"],
+    },
+    {
+        id: "city-leads",
+        title: "City Leads",
+        category: "Community",
+        description: "City Leads organize local meetups, workshops, and hackathons. Learn how to apply and what responsibilities are involved.",
+        keywords: ["city lead", "local", "meetup", "workshop", "ambassador", "leadership", "mentorship", "region", "apply"],
+    },
+    {
+        id: "technical-heads",
+        title: "Technical Heads",
+        category: "Community",
+        description: "Technical Heads design curriculum, review projects, conduct workshops, and maintain open-source repositories.",
+        keywords: ["technical head", "curriculum", "project review", "workshop", "open source", "maintainer", "expert", "pr review"],
+    },
+    {
+        id: "wp-community",
+        title: "WhatsApp Community",
+        category: "Community",
+        description: "Join the WhatsApp group for instant updates, bug help, daily tech discussions, polls, and quizzes.",
+        keywords: ["whatsapp", "chat", "group", "instant", "updates", "discussions", "polls", "quiz", "notifications"],
+    },
+    {
+        id: "hackfiesta",
+        title: "HackFiesta",
+        category: "Community",
+        description: "DevPath's flagship 48-hour annual hackathon with mentors, cash prizes, swag, and networking opportunities.",
+        keywords: ["hackathon", "hackfiesta", "48 hour", "prizes", "swag", "mentors", "networking", "annual", "event", "coding competition"],
+    },
+    {
+        id: "guidelines",
+        title: "Code of Conduct",
+        category: "Community",
+        description: "Our community standards: be respectful, inclusive, avoid harassment and discrimination, and give only constructive criticism.",
+        keywords: ["conduct", "rules", "guidelines", "respect", "inclusive", "harassment", "safe", "standards", "community rules"],
+    },
+    {
+        id: "contributing",
+        title: "How to Contribute",
+        category: "Community",
+        description: "Fork the repo, create a feature branch, commit changes, and open a Pull Request to contribute to DevPath.",
+        keywords: ["contribute", "fork", "pull request", "pr", "branch", "git", "open source", "commit", "github"],
+    },
+    {
+        id: "open-source",
+        title: "Open Source at DevPath",
+        category: "Community",
+        description: "Explore active repositories, pick good-first-issue tickets, submit PRs, and earn open source badges and extra XP.",
+        keywords: ["open source", "github", "repository", "good first issue", "pr", "badge", "xp", "contribution", "maintainer"],
+    },
+];

--- a/src/utils/wikiSearch.ts
+++ b/src/utils/wikiSearch.ts
@@ -1,0 +1,103 @@
+export type SearchableArticle = {
+    id: string;
+    title: string;
+    description: string;
+    keywords: string[];
+    category: string;
+};
+
+export type SearchResult = {
+    id: string;
+    title: string;
+    description: string;
+    keywords: string[];
+    category: string;
+    score: number;
+    titleMatch: boolean;
+    descriptionMatch: boolean;
+    keywordMatches: string[];
+};
+
+/**
+ * Simple fuzzy/partial match: checks if every word in the query
+ * appears somewhere in the target string (case-insensitive).
+ */
+function fuzzyMatch(query: string, target: string): boolean {
+    const words = query.toLowerCase().trim().split(/\s+/);
+    const t = target.toLowerCase();
+    return words.every(word => t.includes(word));
+}
+
+/**
+ * Score an article against the query. Higher = better match.
+ * Title matches are worth more than keyword or description matches.
+ */
+function scoreArticle(article: SearchableArticle, query: string): number {
+    let score = 0;
+    const q = query.toLowerCase().trim();
+
+    if (article.title.toLowerCase().includes(q)) score += 10;
+    else if (fuzzyMatch(query, article.title)) score += 6;
+
+    const keywordMatchCount = article.keywords.filter(k =>
+        k.toLowerCase().includes(q) || fuzzyMatch(query, k)
+    ).length;
+    score += keywordMatchCount * 4;
+
+    if (article.description.toLowerCase().includes(q)) score += 3;
+    else if (fuzzyMatch(query, article.description)) score += 1;
+
+    return score;
+}
+
+/**
+ * Search articles and return scored, sorted results.
+ */
+export function searchArticles(
+    articles: SearchableArticle[],
+    query: string
+): SearchResult[] {
+    if (!query.trim()) return [];
+
+    return articles
+        .map(article => {
+            const score = scoreArticle(article, query);
+            const q = query.toLowerCase().trim();
+
+            const titleMatch =
+                article.title.toLowerCase().includes(q) ||
+                fuzzyMatch(query, article.title);
+
+            const descriptionMatch =
+                article.description.toLowerCase().includes(q) ||
+                fuzzyMatch(query, article.description);
+
+            const keywordMatches = article.keywords.filter(
+                k => k.toLowerCase().includes(q) || fuzzyMatch(query, k)
+            );
+
+            return { ...article, score, titleMatch, descriptionMatch, keywordMatches };
+        })
+        .filter(r => r.score > 0)
+        .sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Highlight all occurrences of the query inside text.
+ * Returns an array of { text, highlight } segments.
+ */
+export function highlightText(
+    text: string,
+    query: string
+): { text: string; highlight: boolean }[] {
+    if (!query.trim()) return [{ text, highlight: false }];
+
+    const escaped = query.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escaped})`, 'gi');
+    const parts = text.split(regex);
+
+    return parts.map(part => ({
+        text: part,
+        highlight: regex.test(part),
+    }));
+}


### PR DESCRIPTION
Fix #40 

Summary:-
Implements client-side fuzzy search on the Wiki homepage (src/app/wiki), enabling users to instantly search and filter articles without any page reloads or external dependencies.

What's Changed:-
⚡ Instant fuzzy search across all wiki articles on the Wiki homepage
🎯 Weighted scoring — title matches rank higher than keyword and description matches
✨ Keyword highlighting — matched text is visually highlighted inside search results
🧹 Clear button (✕) — resets search and restores full article list
📦 Zero external dependencies — fully custom implementation

Here's the demo video:-

https://github.com/user-attachments/assets/cc551444-3c76-4102-81fc-5971a4eb17d5

