### PR TITLE
fix: award XP points for project uploads and discussions

### DIFF
--- a/src/components/community/CreateDiscussionModal.tsx
+++ b/src/components/community/CreateDiscussionModal.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { X, Loader2 } from 'lucide-react';
-import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { addDoc, collection, serverTimestamp, updateDoc, doc, increment } from 'firebase/firestore';
+import { POINTS } from '@/lib/points';
 import { db } from '@/lib/firebase';
 
 interface CreateDiscussionModalProps {
@@ -37,6 +38,10 @@ export default function CreateDiscussionModal({ isOpen, onClose, userId, userNam
                 likes: [],
                 replyCount: 0,
                 createdAt: serverTimestamp()
+            });
+            
+            await updateDoc(doc(db, 'members', userId), {
+                points: increment(POINTS.CREATE_DISCUSSION)
             });
 
             onSuccess();

--- a/src/components/projects/ProjectUploadModal.tsx
+++ b/src/components/projects/ProjectUploadModal.tsx
@@ -4,8 +4,9 @@
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { X, Upload, Plus, Trash2, Link as LinkIcon, Video, Image as ImageIcon, Globe, Save } from 'lucide-react';
-import { collection, addDoc, updateDoc, doc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { collection, addDoc, updateDoc, doc, serverTimestamp, setDoc, increment } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { POINTS } from '@/lib/points';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
@@ -157,8 +158,10 @@ export default function ProjectUploadModal({ isOpen, onClose, userId, userEmail,
                 // 2. Set in Subcollection (with same ID)
                 const subcollectionParentId = userId;
                 await setDoc(doc(db, 'members', subcollectionParentId, 'projects', newId), newProjectData);
+                await updateDoc(doc(db, 'members', userId), {
+                    points: increment(POINTS.CREATE_PROJECT)
+                });
             }
-
             onSuccess();
             onClose();
         } catch (error) {


### PR DESCRIPTION
## Summary

Fixed missing gamification XP rewards for:

* Project uploads (`POINTS.CREATE_PROJECT`)
* Discussion creation (`POINTS.CREATE_DISCUSSION`)

## Changes Made

* Added Firestore transactional point increments using `increment()`
* Awarded points only after successful create operations
* Updated:

  * `ProjectUploadModal.tsx`
  * `CreateDiscussionModal.tsx`

## Verification

* TypeScript compilation completed successfully
* No import or build issues introduced by the changes

## Note

Local runtime testing is currently limited due to missing/invalid Firebase environment configuration (`auth/invalid-api-key`) already present in the repository setup.

Screenshots :
<img width="1536" height="1024" alt="screenshots1" src="https://github.com/user-attachments/assets/3ca9228c-28a8-4962-96a6-cae4f73f7818" />

Closes #178
