### PR TITLE
fix: clear NotificationDropdown state on sign-out

### DIFF
--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -48,7 +48,12 @@ export function NotificationDropdown() {
     }, [isOpen, closePanel])
 
     useEffect(() => {
-        if (!user) return;
+        if (!user) {
+            // Clear sensitive state on sign-out / user switch to avoid showing stale notifications.
+            setNotifications([])
+            setIsOpen(false)
+            return
+        }
 
         const q = query(
             collection(db, 'members', user.uid, 'notifications'),


### PR DESCRIPTION
## Description
Clears `NotificationDropdown` state when the authenticated user becomes `null` (sign-out) to prevent stale notifications from the previous session being shown.

Previously, the subscription effect returned early on `!user` without resetting local state, so the last loaded notifications could remain visible after logout. This PR resets `notifications` to an empty list and closes the dropdown on sign-out/user switch.

Fixes #183

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] Local testing
- [ ] Vercel Preview Deployment

Local verification steps:
1. Sign in as User A → open the notification dropdown → confirm notifications render.
2. Sign out → open the dropdown again → confirm it shows empty state (no User A notifications).
3. Sign in as User B → open the dropdown → confirm only User B notifications are shown.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact