### PR TITLE
fix: show FollowButton for guest users

### DIFF
--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -48,7 +48,7 @@ export default function FollowButton({ targetUserId, targetRole = 'member', targ
         }
     };
 
-    if (!user || user.uid === targetUserId) return null;
+    if (user && user.uid === targetUserId) return null;
 
     return (
         <button


### PR DESCRIPTION
Fix #184 

## Problem
The FollowButton component had a render guard:
if (!user || user.uid === targetUserId) return null;

This caused the button to be completely hidden for guest/unauthenticated users due to the `!user` condition, making the login prompt inside `handleFollowToggle` unreachable dead code.

## Fix
Updated the render guard to only hide the button when a logged-in user views their own profile:
if (user && user.uid === targetUserId) return null;

## Behavior After Fix
- ✅ Guest users can now see the Follow button
- ✅ Clicking it triggers the existing "Please login to follow users." alert
- ✅ Logged-in users viewing their own profile still don't see the button
- ✅ Logged-in users viewing other profiles can follow normally

## Changes
- `src/components/profile/FollowButton.tsx` — one line change at L51