### PR TITLE
Fix #180: Replace hardcoded join date fallback with dynamic label

### DIFF
--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -389,13 +389,13 @@ useEffect(() => {
                             <div className="flex items-center gap-2 text-muted-foreground">
                                 <Calendar size={16} />
                                 <span>Joined {(() => {
-                                    if (!user.createdAt) return 'Dec 2023';
+                                    if (!user.createdAt) return 'Recently';
                                     try {
                                         const d = new Date(user.createdAt.seconds ? user.createdAt.seconds * 1000 : user.createdAt);
-                                        if (isNaN(d.getTime())) return 'Dec 2023';
+                                        if (isNaN(d.getTime())) return 'Recently';
                                         return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
                                     } catch (e) {
-                                        return 'Dec 2023';
+                                        return 'Recently';
                                     }
                                 })()}</span>
                             </div>


### PR DESCRIPTION
## Description

Fixes #180

This PR removes the hardcoded `Dec 2023` fallback used when rendering a user's join date in the profile sidebar.

Previously, if `user.createdAt` was missing or failed to parse during loading states, the UI would incorrectly display `Joined Dec 2023`, which could mislead users who registered after that date.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Local testing

### Testing Performed
- Verified valid dates continue to render correctly
- Verified missing or invalid dates display `Recently`
- Tested locally using the development server

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact