### PR TITLE
Fix #179: Replace client-side createdAt with Firestore serverTimestamp

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -7,7 +7,7 @@ import { motion } from 'framer-motion';
 import { User, Mail, Lock, Phone, Github, Linkedin, Instagram, ArrowRight, MapPin, Key } from 'lucide-react';
 import Link from 'next/link';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
-import { doc, setDoc, getDoc } from 'firebase/firestore';
+import { doc, setDoc, getDoc, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '@/lib/firebase';
 
 // const ADMIN_KEY = "DEVPATH_CORE_2025"; // Removed in favor of dynamic key
@@ -124,7 +124,7 @@ export default function SignupPage() {
                     github,
                     instagram,
                     role: 'member',
-                    createdAt: new Date().toISOString(),
+                    createdAt: serverTimestamp(),
                     xp: 0,
                     rank: 0,
                     streak: 0,


### PR DESCRIPTION
## Description

Fixes #179

This PR replaces the client-side generated ISO timestamp used during signup with Firestore's `serverTimestamp()`.

### Changes Made

- Added `serverTimestamp` import from `firebase/firestore`
- Replaced `createdAt: new Date().toISOString()` with `createdAt: serverTimestamp()`
- Preserved the existing signup flow and user creation logic

### Benefits

- Ensures consistent timestamp storage across all user records
- Aligns signup page behavior with the existing implementation in `AuthContext.tsx`
- Prevents mixed ISO string and Firestore Timestamp formats in Firestore
- Avoids date parsing inconsistencies in profile views and related components

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Verified the code compiles successfully
- [x] Confirmed only `src/app/signup/page.tsx` was modified
- [x] Verified the signup flow remains unchanged apart from timestamp creation