### PR TITLE
fix: make project upload and update writes atomic using writeBatch

### DIFF
--- a/src/components/projects/ProjectUploadModal.tsx
+++ b/src/components/projects/ProjectUploadModal.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { X, Upload, Plus, Trash2, Link as LinkIcon, Video, Image as ImageIcon, Globe, Save } from 'lucide-react';
-import { collection, addDoc, updateDoc, doc, serverTimestamp, setDoc, increment } from 'firebase/firestore';
+import { collection, writeBatch, doc, serverTimestamp, increment } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { POINTS } from '@/lib/points';
 import ReactMarkdown from 'react-markdown';
@@ -118,26 +118,23 @@ export default function ProjectUploadModal({ isOpen, onClose, userId, userEmail,
                 updatedAt: serverTimestamp()
             };
 
+            const batch = writeBatch(db);
+
             if (initialData?.id) {
-                // Update existing project
-                const projectDataWithTimestamp = { ...projectData, updatedAt: serverTimestamp() };
+                // --- Update existing project (atomic) ---
+                // Both the root collection and the member subcollection are updated in a
+                // single batch so neither can succeed while the other fails.
+                const rootRef = doc(db, 'projects', initialData.id);
+                const subRef  = doc(db, 'members', userId, 'projects', initialData.id);
 
-                // 1. Update in Root Collection (Main Source)
-                try {
-                    await updateDoc(doc(db, 'projects', initialData.id), projectDataWithTimestamp);
-                } catch (e) {
-                    console.warn("Could not update root doc (might not exist):", e);
-                }
-
-                // 2. Update in Subcollection (Legacy/Backup)
-                try {
-                    const subcollectionParentId = userId;
-                    await updateDoc(doc(db, 'members', subcollectionParentId, 'projects', initialData.id), projectDataWithTimestamp);
-                } catch (e) {
-                    console.warn("Could not update subcollection doc:", e);
-                }
+                batch.update(rootRef, projectData);
+                batch.update(subRef,  projectData);
             } else {
-                // Create new project
+                // --- Create new project (atomic) ---
+                // A shared document ID is generated once and used for both writes so the
+                // two collections always stay in sync.
+                const newId = doc(collection(db, 'projects')).id;
+
                 const newProjectData = {
                     ...projectData,
                     userId,
@@ -148,24 +145,23 @@ export default function ProjectUploadModal({ isOpen, onClose, userId, userEmail,
                     starCount: 0
                 };
 
-                // Generate ID
-                const newDocRef = doc(collection(db, 'projects'));
-                const newId = newDocRef.id;
+                const rootRef    = doc(db, 'projects', newId);
+                const subRef     = doc(db, 'members', userId, 'projects', newId);
+                const memberRef  = doc(db, 'members', userId);
 
-                // 1. Set in Root Collection
-                await setDoc(doc(db, 'projects', newId), newProjectData);
-
-                // 2. Set in Subcollection (with same ID)
-                const subcollectionParentId = userId;
-                await setDoc(doc(db, 'members', subcollectionParentId, 'projects', newId), newProjectData);
-                await updateDoc(doc(db, 'members', userId), {
-                    points: increment(POINTS.CREATE_PROJECT)
-                });
+                batch.set(rootRef,   newProjectData);
+                batch.set(subRef,    newProjectData);
+                // XP award is part of the same atomic batch — it only lands if both
+                // project writes succeed.
+                batch.update(memberRef, { points: increment(POINTS.CREATE_PROJECT) });
             }
+
+            await batch.commit();
+
             onSuccess();
             onClose();
         } catch (error) {
-            console.error("Error saving project:", error);
+            console.error('Error saving project:', error);
             alert(`Failed to save project: ${error instanceof Error ? error.message : 'Unknown error'}`);
         } finally {
             setLoading(false);


### PR DESCRIPTION
# fix: make project upload and update writes atomic using writeBatch #173 

## Technical Summary

This PR addresses a critical race condition and database desynchronization vulnerability in `ProjectUploadModal`. Previously, writes to the `projects` root collection and `members/{uid}/projects` subcollection were executed as non-atomic, sequential operations. This left a window where network interruptions, client-side crashes, or partial permission failures could result in "zombie" or orphaned documents.

We resolve this by migrating from sequential `setDoc`/`updateDoc` API calls to a transactional `writeBatch`. This guarantees Atomicity (the "A" in ACID) for multi-document writes — all operations succeed, or the entire transaction is rolled back.

## Vulnerability Addressed

In the previous architecture, the operation sequence was:
1. `updateDoc` / `setDoc` to `projects/{id}` (Global Collection)
2. `updateDoc` / `setDoc` to `members/{uid}/projects/{id}` (User Subcollection)
3. `updateDoc` to `members/{uid}` (XP Points Increment - *Create Only*)

If step 1 succeeded but step 2 failed (e.g., due to sudden offline status, or transient network timeouts), the project would appear in the global community feed but would be missing from the user's personal profile card. This also resulted in silent failure states, as the original implementation swallowed errors in individual `catch` blocks without reverting previous successful writes.

## Code Changes & Diff

We deprecated individual sequential document manipulations in favor of a single Firestore batch commit.

### Before (Vulnerable Sequential Writes)

```typescript
// Create new project path
const newDocRef = doc(collection(db, 'projects'));
const newId = newDocRef.id;

// 1. Set in Root Collection
await setDoc(doc(db, 'projects', newId), newProjectData);

// 2. Set in Subcollection
await setDoc(doc(db, 'members', userId, 'projects', newId), newProjectData);

// 3. Increment XP
await updateDoc(doc(db, 'members', userId), {
    points: increment(POINTS.CREATE_PROJECT)
});
```

### After (Atomic Batch)

```typescript
const batch = writeBatch(db);
const newId = doc(collection(db, 'projects')).id;

// Create references
const rootRef   = doc(db, 'projects', newId);
const subRef    = doc(db, 'members', userId, 'projects', newId);
const memberRef = doc(db, 'members', userId);

// Stage operations in memory
batch.set(rootRef, newProjectData);
batch.set(subRef,  newProjectData);
batch.update(memberRef, { points: increment(POINTS.CREATE_PROJECT) });

// Execute atomically
await batch.commit();
```

The same architectural pattern was applied to the **Update** logic, switching `await updateDoc(...)` calls to `batch.update(...)` prior to the final commit.

## Database & Performance Impact

1. **Integrity:** Zero risk of partial project states. The UI will no longer encounter broken refs attempting to map between global and subcollection projects.
2. **Network Efficiency:** Instead of 3 separate HTTP/RPC requests to the Firestore backend, the client now makes a single request containing the batch payload. This reduces latency overhead for users on poor connections.
3. **Billing:** The number of document writes billed remains unchanged (still 3 writes per creation), but connection overhead is reduced.

## Testing Instructions

1. **Happy Path:** Open the `ProjectUploadModal`, submit a new project, and verify it populates in both the global "Projects" feed and the User Profile tab. Verify XP has incremented by the defined `CREATE_PROJECT` constant.
2. **Atomic Rollback Simulation:** 
   - Open Chrome DevTools -> Network Tab.
   - Set throttling to "Slow 3G".
   - Submit a new project.
   - Immediately switch Network to "Offline" before the request finishes.
   - Refresh the page and verify that *neither* the root collection nor the subcollection was partially updated.

## Labels

`bug` · `critical` · `firestore` · `atomic-writes`
