### PR TITLE
fix(admin): implement Firestore cursor pagination for members dashboard

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -3,12 +3,19 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { Shield, Database, X } from 'lucide-react';
-import { doc, updateDoc, onSnapshot, collection, getDocs, query, orderBy, addDoc, serverTimestamp, deleteDoc, where, setDoc, arrayRemove, increment, arrayUnion, getDoc } from 'firebase/firestore';
+import { doc, updateDoc, onSnapshot, collection, getDocs, query, orderBy, addDoc, serverTimestamp, deleteDoc, where, setDoc, arrayRemove, increment, arrayUnion, getDoc, limit, startAfter, QueryDocumentSnapshot, DocumentData } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import Image from 'next/image';
 import { determineBadges, getBadgeXp } from '@/lib/point-calculation';
 
+const PAGE_SIZE = 50;
+
 export default function AdminDashboard({ initialAuth = false }: { initialAuth?: boolean }) {
+    // === Pagination States ===
+    const [lastVisible, setLastVisible] = useState<QueryDocumentSnapshot<DocumentData> | null>(null);
+    const [hasMore, setHasMore] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
+
     // === Maintenance States ===
     const [maintenanceMode, setMaintenanceMode] = useState(false);
     const [maintenanceMsg, setMaintenanceMsg] = useState('');
@@ -65,8 +72,13 @@ export default function AdminDashboard({ initialAuth = false }: { initialAuth?: 
         setSearching(true);
         try {
             const membersRef = collection(db, 'members');
-            const membersSnap = await getDocs(membersRef);
-            const membersList = membersSnap.docs.map(doc => ({ uid: doc.id, ...doc.data() }));
+            const membersQuery = query(
+                membersRef,
+                orderBy('createdAt', 'desc'),
+                limit(PAGE_SIZE)
+            );
+            const membersSnap = await getDocs(membersQuery);
+            const membersList = membersSnap.docs.map(doc => ({ uid: doc.id, ...doc.data() } as any));
 
             const adminsRef = collection(db, 'admins');
             const adminsSnap = await getDocs(adminsRef);
@@ -109,10 +121,86 @@ export default function AdminDashboard({ initialAuth = false }: { initialAuth?: 
             const allUsers = Array.from(userMap.values());
             console.log(`Found ${allUsers.length} total users.`);
             setUsers(allUsers);
+
+            const lastVisibleDoc = membersSnap.docs[membersSnap.docs.length - 1] || null;
+            setLastVisible(lastVisibleDoc);
+            setHasMore(membersSnap.docs.length === PAGE_SIZE);
         } catch (error) {
             console.error("Error fetching users:", error);
         } finally {
             setSearching(false);
+        }
+    };
+
+    const loadMoreMembers = async () => {
+        if (loadingMore || !hasMore || !lastVisible) return;
+        setLoadingMore(true);
+        try {
+            const membersRef = collection(db, 'members');
+            const membersQuery = query(
+                membersRef,
+                orderBy('createdAt', 'desc'),
+                startAfter(lastVisible),
+                limit(PAGE_SIZE)
+            );
+            const membersSnap = await getDocs(membersQuery);
+            const membersList = membersSnap.docs.map(doc => ({ uid: doc.id, ...doc.data() } as any));
+
+            if (membersList.length > 0) {
+                const adminsRef = collection(db, 'admins');
+                const adminsSnap = await getDocs(adminsRef);
+                const adminsList = adminsSnap.docs.map(doc => {
+                    const data = doc.data();
+                    return {
+                        uid: doc.id,
+                        ...data,
+                        email: data.email || (doc.id.includes('@') ? doc.id : undefined),
+                        role: 'admin' 
+                    };
+                });
+
+                const userMap = new Map();
+                users.forEach(user => {
+                    if (user.uid) userMap.set(user.uid, user);
+                });
+                membersList.forEach(member => {
+                    if (member.uid) userMap.set(member.uid, member);
+                });
+
+                adminsList.forEach(admin => {
+                    let targetUid = admin.uid;
+                    if (!targetUid || targetUid.includes('@')) {
+                        const matchingMember = membersList.find(m => m.email === admin.email);
+                        if (matchingMember) {
+                            targetUid = matchingMember.uid;
+                        } else {
+                            targetUid = admin.uid || admin.email;
+                        }
+                    }
+
+                    if (targetUid) {
+                        const existing = userMap.get(targetUid);
+                        if (existing) {
+                            userMap.set(targetUid, { ...existing, ...admin, uid: targetUid, role: 'admin' });
+                        } else {
+                            userMap.set(targetUid, { ...admin, uid: targetUid, role: 'admin' });
+                        }
+                    }
+                });
+
+                const allUsers = Array.from(userMap.values());
+                setUsers(allUsers);
+            }
+
+            const lastVisibleDoc = membersSnap.docs[membersSnap.docs.length - 1] || null;
+            if (lastVisibleDoc) {
+                setLastVisible(lastVisibleDoc);
+            }
+            setHasMore(membersSnap.docs.length === PAGE_SIZE);
+        } catch (error) {
+            console.error("Error loading more members:", error);
+        } finally {
+            setLoadingMore(false);
         }
     };
 
@@ -591,6 +679,17 @@ export default function AdminDashboard({ initialAuth = false }: { initialAuth?: 
                 </div>
                 
                 {/* DO NOT DELETE THE REST OF THE UI BELOW THIS IN YOUR FILE */}
+                {hasMore && (
+                    <div className="flex justify-center mt-6">
+                        <button
+                            onClick={loadMoreMembers}
+                            disabled={loadingMore}
+                            className="px-6 py-2 bg-primary text-white rounded-md font-bold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {loadingMore ? 'Loading...' : 'Load More'}
+                        </button>
+                    </div>
+                )}
 
             </div>
         </div>


### PR DESCRIPTION
## Description

Implemented Firestore cursor-based pagination in `src/components/admin/AdminDashboard.tsx` to resolve scalability and performance issues caused by unbounded member queries.

### Changes Made

* Added Firestore pagination utilities:

  * `limit`
  * `startAfter`
  * `QueryDocumentSnapshot`
  * `DocumentData`

* Introduced pagination state management:

  * `PAGE_SIZE = 50`
  * `lastVisible`
  * `hasMore`
  * `loadingMore`

* Refactored the initial member fetch query to:

  * order members by `createdAt`
  * limit results to 50 documents
  * avoid full collection reads

* Added incremental pagination support:

  * implemented `loadMoreMembers()`
  * fetches next batch using `startAfter(lastVisible)`
  * appends results safely to existing state
  * prevents duplicate concurrent requests

* Added minimal pagination UI:

  * "Load More" button
  * disabled during loading
  * hidden when no more members are available

### Performance Improvements

* Prevents downloading thousands of member documents at once
* Reduces Firestore read costs significantly
* Improves browser responsiveness and memory usage
* Ensures admin dashboard remains performant for large communities (10k+ users)

Fixes #175 

---

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

## How Has This Been Tested?

* [x] Local testing
* [ ] Vercel Preview Deployment

### Verification Performed

* Verified initial dashboard load fetches only 50 members
* Verified additional members load incrementally using "Load More"
* Verified users append correctly without duplicates
* Verified pagination state updates correctly
* Verified button disables while loading
* Verified existing dashboard rendering and filtering behavior remain intact

### Notes

`npx tsc --noEmit` currently reports an unrelated pre-existing TypeScript issue in:
`src/components/layout/MaintenanceBlocker.tsx`

This issue is outside the scope of this PR and no unrelated files were modified.

---

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or errors
* [x] I have checked that the "DevPath India" branding remains intact
