### PR TITLE
fix: prevent XP corruption with atomic increments (issue #221)

### DIFF
--- a/src/components/community/CreateDiscussionModal.tsx
+++ b/src/components/community/CreateDiscussionModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { X, Loader2 } from 'lucide-react';
-import { addDoc, collection, serverTimestamp, updateDoc, doc, increment } from 'firebase/firestore';
+import { addDoc, collection, serverTimestamp, updateDoc, doc, increment, setDoc } from 'firebase/firestore';
 import { POINTS } from '@/lib/points';
 import { db } from '@/lib/firebase';
 
@@ -43,6 +43,15 @@ export default function CreateDiscussionModal({ isOpen, onClose, userId, userNam
             await updateDoc(doc(db, 'members', userId), {
                 points: increment(POINTS.CREATE_DISCUSSION)
             });
+
+            const today = new Date().toISOString().split('T')[0];
+            await setDoc(doc(db, 'leaderboard', userId), {
+                uid: userId,
+                name: userName,
+                points: increment(POINTS.CREATE_DISCUSSION),
+                role: 'member',
+                lastActive: today
+            }, { merge: true });
 
             onSuccess();
             onClose();

--- a/src/components/projects/ProjectUploadModal.tsx
+++ b/src/components/projects/ProjectUploadModal.tsx
@@ -148,12 +148,21 @@ export default function ProjectUploadModal({ isOpen, onClose, userId, userEmail,
                 const rootRef    = doc(db, 'projects', newId);
                 const subRef     = doc(db, 'members', userId, 'projects', newId);
                 const memberRef  = doc(db, 'members', userId);
+                const leaderboardRef = doc(db, 'leaderboard', userId);
+                const today = new Date().toISOString().split('T')[0];
 
                 batch.set(rootRef,   newProjectData);
                 batch.set(subRef,    newProjectData);
                 // XP award is part of the same atomic batch — it only lands if both
                 // project writes succeed.
                 batch.update(memberRef, { points: increment(POINTS.CREATE_PROJECT) });
+                batch.set(leaderboardRef, {
+                    uid: userId,
+                    name: userName,
+                    points: increment(POINTS.CREATE_PROJECT),
+                    role: 'member',
+                    lastActive: today
+                }, { merge: true });
             }
 
             await batch.commit();

--- a/src/components/resources/QuizComponent.tsx
+++ b/src/components/resources/QuizComponent.tsx
@@ -25,7 +25,7 @@ export interface QuizComponentProps {
  */
 export default function QuizComponent({ quizId, questions, onComplete, title = "Quiz Time" }: QuizComponentProps) {
   const { addXp } = useGamification();
-  const { user, updateUserProfile } = useAuth();
+  const { user, updateUserProfile, awardPoints } = useAuth();
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [selectedAnswer, setSelectedAnswer] = useState("");
@@ -80,13 +80,12 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
             if (!completed.includes(quizId) && passed) {
               const newQuizzes = [...completed, quizId];
               const pointsEarned = isPerfect ? 350 : 200;
-              const newPoints = (user.points || 0) + pointsEarned;
-              
-              // Update Firestore
-              await updateUserProfile({
-                completedQuizzes: newQuizzes,
-                points: newPoints
-              });
+               
+              // Update quiz progress (non-point fields)
+              await updateUserProfile({ completedQuizzes: newQuizzes });
+
+              // Award XP atomically (also keeps leaderboard in sync)
+              await awardPoints(pointsEarned);
 
               // Firestore already received the points update above; this call only shows feedback.
               addXp(

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -79,6 +79,7 @@ interface AuthContextType {
     login: (email: string, pass: string) => Promise<void>;
     logout: () => Promise<void>;
     updateUserProfile: (data: Partial<User>) => Promise<void>;
+    awardPoints: (pointsDelta: number) => Promise<void>;
     followUser: (targetUserId: string, targetRole?: string, targetEmail?: string) => Promise<void>;
     unfollowUser: (targetUserId: string, targetRole?: string, targetEmail?: string) => Promise<void>;
     followCommunity: () => Promise<void>;
@@ -390,18 +391,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 Object.entries(data).filter(([_, v]) => v !== undefined)
             );
 
-            await setDoc(doc(db, collectionName, docId), cleanData, { merge: true });
-
-            // Sync to Leaderboard if points are updated
-            if (data.points !== undefined) {
-                const leaderboardRef = doc(db, 'leaderboard', user.uid);
-                setDoc(leaderboardRef, {
-                    points: data.points,
-                    name: data.name || user.name, // Update name/photo if changed too
-                    photoURL: data.photoURL || user.photoURL,
-                    lastActive: new Date().toISOString().split('T')[0]
-                }, { merge: true }).catch(err => console.error("Error syncing leaderboard:", err));
+            // NOTE: Avoid absolute writes for `points`. Those can overwrite concurrent
+            // `increment()` writes and corrupt XP totals/leaderboard.
+            if ((cleanData as any).points !== undefined) {
+                console.warn("[updateUserProfile] Ignoring `points` field. Use awardPoints(pointsDelta) instead.");
+                delete (cleanData as any).points;
             }
+
+            await setDoc(doc(db, collectionName, docId), cleanData, { merge: true });
 
             // 2. Update Auth Profile (if name or photoURL changed)
             if (data.name || data.photoURL) {
@@ -420,6 +417,39 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             console.error("Error updating profile:", error);
             throw error;
         }
+    };
+
+    const awardPoints = async (pointsDelta: number) => {
+        if (!user || !auth.currentUser) return;
+        if (user.email === SUPER_ADMIN_EMAIL) return; // Super Admin Guard
+        if (!Number.isFinite(pointsDelta) || pointsDelta === 0) return;
+
+        const { writeBatch, increment } = await import('firebase/firestore');
+        const batch = writeBatch(db);
+
+        const collectionName = user.role === 'admin' ? 'admins' : 'members';
+        const docId = user.docId || (user.role === 'admin' ? user.email!.toLowerCase() : user.uid);
+        const userRef = doc(db, collectionName, docId);
+
+        batch.set(userRef, { points: increment(pointsDelta) }, { merge: true });
+
+        const today = new Date().toISOString().split('T')[0];
+        const leaderboardRef = doc(db, 'leaderboard', user.uid);
+        batch.set(leaderboardRef, {
+            uid: user.uid,
+            name: user.name,
+            photoURL: user.photoURL,
+            points: increment(pointsDelta),
+            role: user.role,
+            lastActive: today
+        }, { merge: true });
+
+        await batch.commit();
+
+        setUser(prev => prev ? {
+            ...prev,
+            points: (prev.points || 0) + pointsDelta
+        } : null);
     };
 
     const followUser = async (targetUserId: string, targetRole: string = 'member', targetEmail?: string) => {
@@ -578,7 +608,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     return (
-        <AuthContext.Provider value={{ user, login, logout, updateUserProfile, followUser, unfollowUser, followCommunity, isLoading, isAdminVerified, verifyAdmin }}>
+        <AuthContext.Provider value={{ user, login, logout, updateUserProfile, awardPoints, followUser, unfollowUser, followCommunity, isLoading, isAdminVerified, verifyAdmin }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/context/GamificationContext.tsx
+++ b/src/context/GamificationContext.tsx
@@ -121,7 +121,7 @@ const ToastMessage = ({ n, removeNotification }: { n: GamificationNotification, 
 };
 
 export function GamificationProvider({ children }: { children: React.ReactNode }) {
-    const { user, updateUserProfile } = useAuth();
+    const { user, awardPoints } = useAuth();
     const [notifications, setNotifications] = useState<GamificationNotification[]>([]);
 
     const xp = user?.points || 0;
@@ -138,13 +138,14 @@ export function GamificationProvider({ children }: { children: React.ReactNode }
         options: AddXpOptions = {}
     ) => {
         const shouldPersist = options.persist !== false;
-        const newXp = xp + amount;
-        const currentLevel = Math.floor(Math.sqrt(xp / 100));
+        const currentXp = user?.points || 0;
+        const newXp = currentXp + amount;
+        const currentLevel = Math.floor(Math.sqrt(currentXp / 100));
         const newLevel = Math.floor(Math.sqrt(newXp / 100));
         
         if (user && shouldPersist) {
-            // Persist XP to Firestore securely for authenticated users only.
-            updateUserProfile({ points: newXp }).catch(err => console.error("Failed to update XP", err));
+            // Persist XP using atomic increments to avoid overwriting concurrent updates.
+            awardPoints(amount).catch(err => console.error("Failed to award XP", err));
         }
 
         const baseId = Date.now();


### PR DESCRIPTION
## Description
Fixes XP/points corruption in the gamification system by removing absolute `points` writes that could overwrite concurrent Firestore `increment()` updates.

Changes:
- Added an `awardPoints(pointsDelta)` helper in `AuthContext` that updates both the user doc and `leaderboard` using atomic `increment()` in a single batch.
- Updated `GamificationContext.addXp()` to persist XP via `awardPoints()` (no stale React closure / no absolute overwrite).
- Updated quiz completion flow to update `completedQuizzes` separately and award XP via `awardPoints()`.
- Synced leaderboard updates for XP awards in project upload and discussion creation flows.

Fixes #221

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] Local testing
- [ ] Vercel Preview Deployment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact