### PR TITLE
Fix orphaned admin documents with atomic batch writes

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { Shield, Database, X } from 'lucide-react';
-import { doc, updateDoc, onSnapshot, collection, getDocs, query, orderBy, addDoc, serverTimestamp, deleteDoc, where, setDoc, arrayRemove, increment, arrayUnion, getDoc, limit, startAfter, QueryDocumentSnapshot, DocumentData } from 'firebase/firestore';
+import { doc, updateDoc, onSnapshot, collection, getDocs, query, orderBy, addDoc, serverTimestamp, deleteDoc, where, setDoc, arrayRemove, increment, arrayUnion, getDoc, limit, startAfter, QueryDocumentSnapshot, DocumentData, writeBatch } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import Image from 'next/image';
 import { determineBadges, getBadgeXp } from '@/lib/point-calculation';
@@ -344,15 +344,17 @@ export default function AdminDashboard({ initialAuth = false }: { initialAuth?: 
         }
         if (!confirm(`Demote ${targetAdmin.name} to Member?`)) return;
         try {
+            const batch = writeBatch(db);
             if (targetAdmin.uid) {
-                await setDoc(doc(db, 'members', targetAdmin.uid), {
+                batch.set(doc(db, 'members', targetAdmin.uid), {
                     ...targetAdmin,
                     role: 'member'
                 }, { merge: true });
             }
             if (targetAdmin.email) {
-                await deleteDoc(doc(db, 'admins', targetAdmin.email));
+                batch.delete(doc(db, 'admins', targetAdmin.email));
             }
+            await batch.commit();
             alert("Admin demoted to Member.");
             fetchAdmins();
         } catch (error) {
@@ -365,11 +367,18 @@ export default function AdminDashboard({ initialAuth = false }: { initialAuth?: 
         if (!confirm("Are you sure you want to delete this user? This action cannot be undone.")) return;
         try {
             const targetUser = users.find(u => u.uid === userId);
-            const collectionName = targetUser?.role === 'admin' ? 'admins' : 'members';
-            await deleteDoc(doc(db, collectionName, userId));
+            const batch = writeBatch(db);
+            
+            batch.delete(doc(db, 'members', userId));
+            
+            if (targetUser?.email) {
+                batch.delete(doc(db, 'admins', targetUser.email));
+            }
+            
+            await batch.commit();
             setUsers(prev => prev.filter(u => u.uid !== userId));
             if (selectedUser?.uid === userId) setSelectedUser(null);
-            alert("User deleted successfully.");
+            alert("User deleted from all records.");
         } catch (error) {
             console.error("Error deleting user:", error);
             alert("Failed to delete user.");


### PR DESCRIPTION
# PR Description: Fix Orphaned Admin Documents on Deletion/Demotion

## Title
Use Atomic Batch Writes for Admin Deletion and Demotion to Prevent Orphaned Documents

## Issue Addressed
**Severity**: Advanced

**File**: `src/components/admin/AdminDashboard.tsx` (Lines 516 to 531 context)

**Description**:
Administrators are stored in both the `admins` collection (keyed by email) and the `members` collection (keyed by UID). When `handleDeleteUser` was triggered from the admin dashboard, it determined the target collection based solely on the user's active client-side role. 
As a result, deleting an admin user only deleted their entry in the `admins` collection, leaving their `members` profile document orphaned. Furthermore, demoting an admin deleted their email key in `admins` but used non-atomic sequential writes which could fail to reset their profile role flag in the `members` collection. This led to data inflation and inconsistency, where defunct administrators still had valid member documents bypassing standard security validations.

## Changes Made
*   Imported `writeBatch` from `firebase/firestore`.
*   Refactored `handleDeleteUser` to use `writeBatch`, atomically deleting the user from both the `members` collection and the `admins` collection.
*   Refactored `handleDemoteToMember` to use `writeBatch` as well, ensuring that the profile update in the `members` collection and the deletion from the `admins` collection either succeed or fail together.

## Steps to Verify
1. Promote a user to Admin in the Admin panel.
2. Verify they have documents in both `members` (using UID) and `admins` (using email).
3. Delete the admin user via the admin dashboard, or demote them back to member.
4. Verify that their document in the `admins` collection is removed, and their document under the `members` collection is appropriately deleted (if deleted) or securely updated to member (if demoted).

This fix completely eliminates the risk of orphaned admin profile documents and enforces referential integrity across the users and admins collections.
 
### Close issue  - #174 