### PR TITLE
Fix stored XSS in profile social links

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
 import { doc, setDoc, getDoc } from 'firebase/firestore';
 import { auth, db } from '@/lib/firebase';
+import { sanitizeSocialLinks } from '@/lib/safe-social-url';
 
 // const ADMIN_KEY = "DEVPATH_CORE_2025"; // Removed in favor of dynamic key
 
@@ -91,6 +92,7 @@ export default function SignupPage() {
 
             // 2. Update Profile Name
             await updateProfile(user, { displayName: name });
+            const safeSocialLinks = sanitizeSocialLinks({ linkedin, github, instagram });
 
             // 3. Create Document in Firestore
             if (isAdminSignup) {
@@ -104,9 +106,7 @@ export default function SignupPage() {
                     state,
                     city,
                     district,
-                    linkedin,
-                    github,
-                    instagram,
+                    ...safeSocialLinks,
                     // Preserve existing fields if any (merge is true by default for setDoc if we use { merge: true } but here we want to overwrite/add)
                     // Actually, let's use merge to not lose seeded data like role/name if they match
                 }, { merge: true });
@@ -120,9 +120,7 @@ export default function SignupPage() {
                     state,
                     city,
                     district,
-                    linkedin,
-                    github,
-                    instagram,
+                    ...safeSocialLinks,
                     role: 'member',
                     createdAt: new Date().toISOString(),
                     xp: 0,

--- a/src/app/u/client.tsx
+++ b/src/app/u/client.tsx
@@ -15,6 +15,7 @@ import DOMPurify from 'dompurify';
 import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
 import { GIT_FALLBACK_STATS } from '@/lib/github';
+import { getSafeSocialUrl } from '@/lib/safe-social-url';
 
 interface PublicUser {
     id?: string;
@@ -365,6 +366,11 @@ function ProfileContent() {
 
     const showMobile = user.privacySettings?.showMobile;
     const showLocation = user.privacySettings?.showLocation ?? true;
+    const safeSocialLinks = {
+        github: getSafeSocialUrl(user.github, 'github'),
+        linkedin: getSafeSocialUrl(user.linkedin, 'linkedin'),
+        instagram: getSafeSocialUrl(user.instagram, 'instagram')
+    };
 
     return (
         <section className={styles.profile}>
@@ -421,18 +427,18 @@ function ProfileContent() {
                             </div>
 
                             <div className="flex flex-wrap gap-3 mt-3">
-                                {user.github && (
-                                    <a href={user.github} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm hover:text-primary transition-colors">
+                                {safeSocialLinks.github && (
+                                    <a href={safeSocialLinks.github} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm hover:text-primary transition-colors">
                                         <Github size={14} /> GitHub
                                     </a>
                                 )}
-                                {user.linkedin && (
-                                    <a href={user.linkedin} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm hover:text-primary transition-colors">
+                                {safeSocialLinks.linkedin && (
+                                    <a href={safeSocialLinks.linkedin} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm hover:text-primary transition-colors">
                                         <Linkedin size={14} /> LinkedIn
                                     </a>
                                 )}
-                                {user.instagram && (
-                                    <a href={user.instagram} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm hover:text-primary transition-colors">
+                                {safeSocialLinks.instagram && (
+                                    <a href={safeSocialLinks.instagram} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-sm hover:text-primary transition-colors">
                                         <Instagram size={14} /> Instagram
                                     </a>
                                 )}

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -23,6 +23,7 @@ import { db } from '@/lib/firebase';
 import { calculateLevel } from '@/lib/points';
 import { getEmbedUrl } from '@/lib/utils';
 import { GIT_FALLBACK_STATS } from '@/lib/github';
+import { getSafeSocialUrl, sanitizeSocialLinks } from '@/lib/safe-social-url';
 
 /**
  * UserProfile component renders the main dashboard profile page for authenticated developers.
@@ -215,16 +216,17 @@ useEffect(() => {
     const handleSaveAbout = async () => {
         setIsSaving(true);
         try {
+            const safeSocialLinks = sanitizeSocialLinks(socialLinks);
+
             await updateUserProfile({
                 aboutMarkdown: aboutContent,
-                github: socialLinks.github,
-                linkedin: socialLinks.linkedin,
-                instagram: socialLinks.instagram
+                ...safeSocialLinks
             });
+            setSocialLinks(safeSocialLinks);
             setIsEditingAbout(false);
         } catch (error) {
             console.error("Failed to update profile:", error);
-            alert("Failed to update profile. Please try again.");
+            alert(error instanceof Error ? error.message : "Failed to update profile. Please try again.");
         } finally {
             setIsSaving(false);
         }
@@ -292,6 +294,12 @@ useEffect(() => {
             </div>
         );
     }
+
+    const safeSocialLinks = {
+        github: getSafeSocialUrl(user.github, 'github'),
+        linkedin: getSafeSocialUrl(user.linkedin, 'linkedin'),
+        instagram: getSafeSocialUrl(user.instagram, 'instagram')
+    };
 
     return (
         <div className="min-h-screen bg-background text-foreground pb-8 px-4 md:px-8">
@@ -401,9 +409,9 @@ useEffect(() => {
                         </div>
 
                         <div className="flex gap-3 mt-6">
-                            {user.github && <a href={user.github} target="_blank" className="text-muted-foreground hover:text-foreground"><Github size={20} /></a>}
-                            {user.linkedin && <a href={user.linkedin} target="_blank" className="text-muted-foreground hover:text-foreground"><Linkedin size={20} /></a>}
-                            {user.instagram && <a href={user.instagram} target="_blank" className="text-muted-foreground hover:text-foreground"><Instagram size={20} /></a>}
+                            {safeSocialLinks.github && <a href={safeSocialLinks.github} target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground"><Github size={20} /></a>}
+                            {safeSocialLinks.linkedin && <a href={safeSocialLinks.linkedin} target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground"><Linkedin size={20} /></a>}
+                            {safeSocialLinks.instagram && <a href={safeSocialLinks.instagram} target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground"><Instagram size={20} /></a>}
                         </div>
                     </div>
 

--- a/src/lib/safe-social-url.ts
+++ b/src/lib/safe-social-url.ts
@@ -1,0 +1,51 @@
+export type SocialPlatform = 'github' | 'linkedin' | 'instagram';
+
+type SocialLinks = Partial<Record<SocialPlatform, string>>;
+
+const ALLOWED_SOCIAL_HOSTS: Record<SocialPlatform, string[]> = {
+    github: ['github.com'],
+    linkedin: ['linkedin.com'],
+    instagram: ['instagram.com']
+};
+
+const SOCIAL_LABELS: Record<SocialPlatform, string> = {
+    github: 'GitHub',
+    linkedin: 'LinkedIn',
+    instagram: 'Instagram'
+};
+
+export const sanitizeSocialUrl = (value: string | undefined, platform: SocialPlatform): string => {
+    const trimmedValue = value?.trim() || '';
+
+    if (!trimmedValue) return '';
+
+    let url: URL;
+    try {
+        url = new URL(trimmedValue);
+    } catch {
+        throw new Error(`${SOCIAL_LABELS[platform]} URL must be a valid https:// URL.`);
+    }
+
+    const hostname = url.hostname.toLowerCase().replace(/^www\./, '');
+
+    if (url.protocol !== 'https:' || !ALLOWED_SOCIAL_HOSTS[platform].includes(hostname)) {
+        throw new Error(`${SOCIAL_LABELS[platform]} URL must use https:// and match ${ALLOWED_SOCIAL_HOSTS[platform][0]}.`);
+    }
+
+    url.hash = '';
+    return url.toString();
+};
+
+export const sanitizeSocialLinks = (links: SocialLinks): Record<SocialPlatform, string> => ({
+    github: sanitizeSocialUrl(links.github, 'github'),
+    linkedin: sanitizeSocialUrl(links.linkedin, 'linkedin'),
+    instagram: sanitizeSocialUrl(links.instagram, 'instagram')
+});
+
+export const getSafeSocialUrl = (value: string | undefined, platform: SocialPlatform): string | null => {
+    try {
+        return sanitizeSocialUrl(value, platform) || null;
+    } catch {
+        return null;
+    }
+};


### PR DESCRIPTION
## Summary
- add shared social URL validation for GitHub, LinkedIn, and Instagram profile links
- reject non-HTTPS or wrong-domain social URLs before profile/signup data is saved
- render only sanitized social URLs on private and public profile views
- add noopener/noreferrer to the profile social links opened in new tabs

## Verification
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint src/lib/safe-social-url.ts
- git diff --check

Note: a broader ESLint pass on the touched UI files still reports existing unrelated lint debt in those files, so I kept this PR scoped to the security fix.

Closes #226