### PR TITLE
fix(opensource): implement state-based styling and icons for GitHub issues/PRs

### DIFF
--- a/src/components/opensource/GitHubDashboard.tsx
+++ b/src/components/opensource/GitHubDashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import { Github, Star, GitFork, CircleDot, GitPullRequest, BookOpen, Plus, ExternalLink, Loader2, AlertCircle } from 'lucide-react';
+import { Github, Star, GitFork, CircleDot, GitPullRequest, BookOpen, Plus, ExternalLink, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import Link from 'next/link';
 
 interface Repo {
@@ -27,8 +27,12 @@ interface Issue {
     html_url: string;
     state: string;
     created_at: string;
+    closed_at?: string;
     user: {
         login: string;
+    };
+    pull_request?: {
+        url: string;
     };
 }
 
@@ -244,24 +248,33 @@ export default function GitHubDashboard({ accessToken }: GitHubDashboardProps) {
                                 {loadingIssues ? (
                                     <div className="text-center py-4 text-muted-foreground text-sm">Loading issues...</div>
                                 ) : issues.length > 0 ? (
-                                    issues.map(issue => (
-                                        <div key={issue.id} className="flex items-center justify-between p-3 bg-muted/20 rounded-lg hover:bg-muted/40 transition-colors">
-                                            <div className="flex items-center gap-3 overflow-hidden">
-                                                {issue.html_url.includes('pull') ? (
-                                                    <GitPullRequest size={16} className="text-purple-500 shrink-0" />
-                                                ) : (
-                                                    <CircleDot size={16} className="text-green-500 shrink-0" />
-                                                )}
-                                                <span className="text-sm font-medium truncate">
-                                                    <span className="text-muted-foreground mr-2">#{issue.number}</span>
-                                                    {issue.title}
-                                                </span>
+                                    issues.map(issue => {
+                                        const isPR = !!issue.pull_request || issue.html_url.includes('pull');
+                                        const isClosed = issue.state === 'closed';
+
+                                        return (
+                                            <div key={issue.id} className="flex items-center justify-between p-3 bg-muted/20 rounded-lg hover:bg-muted/40 transition-colors">
+                                                <div className="flex items-center gap-3 overflow-hidden">
+                                                    {isPR ? (
+                                                        <GitPullRequest size={16} className={isClosed ? "text-muted-foreground shrink-0" : "text-purple-500 shrink-0"} />
+                                                    ) : (
+                                                        isClosed ? (
+                                                            <CheckCircle2 size={16} className="text-muted-foreground shrink-0" />
+                                                        ) : (
+                                                            <CircleDot size={16} className="text-green-500 shrink-0" />
+                                                        )
+                                                    )}
+                                                    <span className={`text-sm font-medium truncate ${isClosed ? 'text-muted-foreground' : ''}`}>
+                                                        <span className="text-muted-foreground mr-2">#{issue.number}</span>
+                                                        {issue.title}
+                                                    </span>
+                                                </div>
+                                                <Link href={issue.html_url} target="_blank" className="text-xs text-muted-foreground hover:text-primary whitespace-nowrap ml-2">
+                                                    View
+                                                </Link>
                                             </div>
-                                            <Link href={issue.html_url} target="_blank" className="text-xs text-muted-foreground hover:text-primary whitespace-nowrap ml-2">
-                                                View
-                                            </Link>
-                                        </div>
-                                    ))
+                                        );
+                                    })
                                 ) : (
                                     <div className="text-center py-4 text-muted-foreground text-sm">No recent issues found.</div>
                                 )}


### PR DESCRIPTION
# PR Description

## Description
This PR addresses a UI bug in the Open Source Hub Dashboard where closed issues and pull requests were rendered identically to open ones, using active green and purple markers. This caused confusion for contributors because active and completed items were not easy to distinguish.

## Key Changes
- **State-based styling:** Applied `text-muted-foreground` (gray) to closed and merged items so they clearly appear inactive.
- **Improved iconography:** Replaced the generic dot with the `CheckCircle2` icon for closed issues, aligning the UI more closely with GitHub conventions.
- **Reliable PR detection:** Updated the `Issue` interface and detection logic to use the `pull_request` object from the GitHub API, so pull requests are identified and styled correctly regardless of state.
- **Visual consistency:** The entire row, including icon, issue number, and title, now reflects the item status.

Fixes #247 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] **Local testing:** Verified by temporarily injecting mock data into the component state to simulate:
  - Open Issues (`Green CircleDot`)
  - Closed Issues (`Gray CheckCircle2`)
  - Open Pull Requests (`Purple GitPullRequest`)
  - Merged Pull Requests (`Gray GitPullRequest`)
- [x] **Live verification:** Confirmed that the live fetching logic correctly maps real GitHub API responses to the new UI states.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (interface updates)
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact