### PR TITLE
fix: close DeveloperMindsetModal on backdrop click

### DIFF
--- a/src/components/resources/DeveloperMindsetModal.tsx
+++ b/src/components/resources/DeveloperMindsetModal.tsx
@@ -29,13 +29,17 @@ export function DeveloperMindsetModal({ isOpen, onClose }: DeveloperMindsetModal
 
     return createPortal(
         <AnimatePresence>
-            <div className="fixed inset-0 z-[2000] flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm">
-                <motion.div
-                    initial={{ opacity: 0, scale: 0.95 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.95 }}
-                    className="bg-card w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-2xl border border-border shadow-2xl custom-scrollbar"
-                >
+            <div 
+             className="fixed inset-0 z-[2000] flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm"
+             onClick={onClose}
+            >
+               <motion.div
+               initial={{ opacity: 0, scale: 0.95 }}
+               animate={{ opacity: 1, scale: 1 }}
+               exit={{ opacity: 0, scale: 0.95 }}
+               onClick={e => e.stopPropagation()}
+               className="bg-card w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-2xl border border-border shadow-2xl custom-scrollbar"
+               >
                     {/* Header */}
                     <div className="sticky top-0 z-10 flex items-center justify-between p-6 border-b border-border bg-card/95 backdrop-blur">
                         <div>


### PR DESCRIPTION
Fix #256 

## Problem
- Clicking the dark backdrop overlay of DeveloperMindsetModal did not trigger the onClose handler. Users were forced to click  the small X button to close the modal.

## Fix
-Added onClick={onClose} to the backdrop overlay div
-Added onClick={e => e.stopPropagation()} to the inner modal card to prevent click events from bubbling up when clicking inside the modal

## Changes
- src/components/resources/DeveloperMindsetModal.tsx — Lines 33 & 36
