### PR TITLE
fix redundant count queries in Achievements.tsx

### DIFF
--- a/src/components/profile/Achievements.tsx
+++ b/src/components/profile/Achievements.tsx
@@ -39,7 +39,7 @@ export default function Achievements() {
         };
 
         fetchData();
-    }, [user]);
+    }, [user?.uid, user?.points]);
 
     if (!user) return null;
 


### PR DESCRIPTION
Fix #254 

## Problem
- The useEffect in Achievements.tsx used the entire user object as a dependency. Since the user object reference changes frequently on minor profile updates, this caused expensive getCountFromServer() Firebase queries to fire repeatedly and unnecessarily.

## Fix
- Changed the dependency array from [user] to [user?.uid, user?.points] so the effect only re-runs when truly necessary values change.

## Changes
- src/components/profile/Achievements.tsx — Line 42


