### PR TITLE
feat: replace native tooltips with Radix UI tooltips in LoginHeatmap

### DIFF
--- a/src/components/profile/LoginHeatmap.tsx
+++ b/src/components/profile/LoginHeatmap.tsx
@@ -9,19 +9,10 @@ interface LoginHeatmapProps {
 }
 
 export default function LoginHeatmap({ loginDates = [] }: LoginHeatmapProps) {
-    // Ensure loginDates is an array (handle null from Firestore)
     const safeLoginDates = Array.isArray(loginDates) ? loginDates : [];
 
-    // Generate last 365 days
     const days = useMemo(() => {
         const dates = [];
-        // We want the grid to end at "Today (IST)"
-        // So we start from today and go back 364 days
-        const todayIST = new Date();
-        // Note: getISTDateString takes a Date object and returns the string YYYY-MM-DD in IST.
-        // But here we need to iterate.
-        // Let's create a helper or just iterate using the same offset logic.
-
         const nowMs = Date.now();
         for (let i = 364; i >= 0; i--) {
             const d = new Date(nowMs - i * 24 * 60 * 60 * 1000);
@@ -30,7 +21,6 @@ export default function LoginHeatmap({ loginDates = [] }: LoginHeatmapProps) {
         return dates;
     }, []);
 
-    // Calculate streaks
     const { currentStreak, maxStreak } = useMemo(() => calculateStreak(safeLoginDates), [safeLoginDates]);
 
     return (
@@ -42,22 +32,28 @@ export default function LoginHeatmap({ loginDates = [] }: LoginHeatmapProps) {
                     <span>Longest Streak: <strong className="text-foreground">{maxStreak} days</strong></span>
                 </div>
             </div>
-
-            <div className="flex flex-wrap gap-[2px] justify-center md:justify-start">
-                {days.map(date => {
-                    const isLoggedIn = safeLoginDates.includes(date);
-                    return (
-                        <div
-                            key={date}
-                            title={`${date}: ${isLoggedIn ? 'Logged In' : 'No Activity'}`}
-                            className={`w-2.5 h-2.5 rounded-sm transition-colors ${isLoggedIn
-                                ? 'bg-green-500 hover:bg-green-400'
-                                : 'bg-muted/30 hover:bg-muted/50'
-                                }`}
-                        />
-                    );
-                })}
-            </div>
+            <TooltipProvider>
+                <div className="flex flex-wrap gap-[2px] justify-center md:justify-start">
+                    {days.map(date => {
+                        const isLoggedIn = safeLoginDates.includes(date);
+                        return (
+                            <Tooltip key={date}>
+                                <TooltipTrigger asChild>
+                                    <div
+                                        className={`w-2.5 h-2.5 rounded-sm transition-colors ${isLoggedIn
+                                            ? 'bg-green-500 hover:bg-green-400'
+                                            : 'bg-muted/30 hover:bg-muted/50'
+                                            }`}
+                                    />
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>{date}: {isLoggedIn ? 'Logged In' : 'No Activity'}</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        );
+                    })}
+                </div>
+            </TooltipProvider>
             <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground justify-end">
                 <span>Less</span>
                 <div className="w-2.5 h-2.5 rounded-sm bg-muted/30" />


### PR DESCRIPTION
Fix #248 

## Problem
- LoginHeatmap.tsx imported Shadcn/Radix Tooltip components but used native HTML title attributes instead, displaying basic unstyled browser tooltips that broke visual consistency with the rest of the app.

## Fix
- Removed native title attribute from heatmap grid cells
- Wrapped each cell inside Tooltip, TooltipTrigger, and TooltipContent components
- Wrapped the grid in TooltipProvider for proper Radix context

## Changes
- src/components/profile/LoginHeatmap.tsx