### PR TITLE
fix: add Enter to send behavior in AssistantInput

### DIFF
--- a/src/components/assistant/assistant-input.tsx
+++ b/src/components/assistant/assistant-input.tsx
@@ -34,6 +34,12 @@ export function AssistantInput({
         onSend?.(value.trim());
         setValue("");
     };
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit(e as unknown as React.FormEvent);
+    }
+};
 
     return (
         <form
@@ -59,6 +65,7 @@ export function AssistantInput({
                     onChange={(e) => setValue(e.target.value)}
                     onFocus={() => setIsFocused(true)}
                     onBlur={() => setIsFocused(false)}
+                    onKeyDown={handleKeyDown}
                     rows={1}
                     placeholder={placeholder}
                     disabled={disabled}


### PR DESCRIPTION
Fix #245 

## Problem
- The AssistantInput textarea displayed helper text "Press Enter to send • Shift+Enter for new line" but had no onKeyDown listener, so pressing Enter only inserted a newline instead of sending the message.

## Fix
- Added handleKeyDown function that triggers handleSubmit on Enter key press
- Shift+Enter still works for new lines as expected
- Attached onKeyDown={handleKeyDown} to the textarea element

## Changes
- src/components/assistant/assistant-input.tsx 