### PR TITLE
fix: replace hardcoded locale in User Profile joined date

### DIFF
--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -401,7 +401,7 @@ useEffect(() => {
                                     try {
                                         const d = new Date(user.createdAt.seconds ? user.createdAt.seconds * 1000 : user.createdAt);
                                         if (isNaN(d.getTime())) return 'Dec 2023';
-                                        return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+                                        return d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
                                     } catch (e) {
                                         return 'Dec 2023';
                                     }


### PR DESCRIPTION
Fix #242 

## Problem
- The joined date in UserProfile.tsx used a hardcoded 'en-US' locale, preventing regional date formatting for users in different locales.

## Fix
- Replaced 'en-US' with undefined so the browser automatically uses the user's regional locale setting.

## Changes
- src/components/profile/UserProfile.tsx — Line 404

