### PR TITLE
fix: replace hardcoded max height in AssistantPanel

### DIFF
--- a/src/components/assistant/assistant-panel.tsx
+++ b/src/components/assistant/assistant-panel.tsx
@@ -45,7 +45,7 @@ export function AssistantPanel({
                             "border border-white/10 bg-background/90 shadow-2xl",
                             "backdrop-blur-2xl",
                             "md:bottom-auto md:right-8 md:top-24",
-                            "flex flex-col max-h-[calc(100vh-120px)] md:max-h-96"
+                            "flex flex-col max-h-[calc(100vh-120px)] md:max-h-[calc(100vh-180px)]"
                         )}
                     >
                         <AssistantHeader onClose={onClose} onExpand={onExpand} />


### PR DESCRIPTION
Fix #246 

## Problem
- AssistantPanel had a hardcoded md:max-h-96 (384px) class on desktop view. This was too small to fit the header, greeting, suggestion cards, and input form, causing immediate scroll overflow even before any messages.

## Fix
- Replaced md:max-h-96 with md:max-h-[calc(100vh-180px)] so the panel scales dynamically with the viewport height on desktop screens.

## Changes
- src/components/assistant/assistant-panel.tsx — Line 48