### PR TITLE
fix: replace hardcoded SUPER_ADMIN_EMAIL with env var across admin components

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,15 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your_measurement_id
 
 # -----------------------------------------------------------------------------
+# SUPER ADMIN CONFIGURATION
+# -----------------------------------------------------------------------------
+# This email is used for super admin access to the admin panel (/ap).
+# Must match the value in your Firestore admins collection.
+# -----------------------------------------------------------------------------
+
+NEXT_PUBLIC_SUPER_ADMIN_EMAIL=your_super_admin_email_here
+
+# -----------------------------------------------------------------------------
 # INSTRUCTIONS:
 # 1. Copy this file to .env.local
 # 2. Replace the placeholder values with your actual Firebase project credentials

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -42,7 +42,7 @@ export default function AdminDashboard({ initialAuth = false }: { initialAuth?: 
     });
 
     const { user, isAdminAuthenticated } = useAuth() as any; 
-    const SUPER_ADMIN_EMAIL = "admin@devpath.com"; // Change this to actual super admin email
+    const SUPER_ADMIN_EMAIL = process.env.NEXT_PUBLIC_SUPER_ADMIN_EMAIL;
 
     // ==========================================
     // 1. YOUR MAINTENANCE MODE LISTENER

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -96,7 +96,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const unsubscribeSnapshot = useRef<(() => void) | null>(null);
 
 
-    const SUPER_ADMIN_EMAIL = 'devpathind.community@gmail.com';
+    const SUPER_ADMIN_EMAIL = process.env.NEXT_PUBLIC_SUPER_ADMIN_EMAIL || 'devpathind.community@gmail.com';
 
     useEffect(() => {
         // Ensure persistence is set to local
@@ -377,7 +377,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const updateUserProfile = async (data: Partial<User>) => {
         if (!user || !auth.currentUser) return;
-        if (user.email === 'devpathind.community@gmail.com') return; // Super Admin Guard
+        if (user.email === SUPER_ADMIN_EMAIL) return; // Super Admin Guard
 
         try {
             // 1. Update Firestore
@@ -486,7 +486,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const unfollowUser = async (targetUserId: string, targetRole: string = 'member', targetEmail?: string) => {
         if (!user) return;
-        if (user.email === 'devpathind.community@gmail.com') return; // Super Admin Guard
+        if (user.email === SUPER_ADMIN_EMAIL) return; // Super Admin Guard
         try {
             const batch = (await import('firebase/firestore')).writeBatch(db);
             const arrayRemove = (await import('firebase/firestore')).arrayRemove;
@@ -542,7 +542,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const followCommunity = async () => {
         if (!user) return;
-        if (user.email === 'devpathind.community@gmail.com') return; // Super Admin Guard
+        if (user.email === SUPER_ADMIN_EMAIL) return; // Super Admin Guard
         // Check if already followed (using a flag or badge)
         if (user.achievements?.includes('community_follower')) return;
 


### PR DESCRIPTION
## Description

Replaced the hardcoded `SUPER_ADMIN_EMAIL` values across admin components with `process.env.NEXT_PUBLIC_SUPER_ADMIN_EMAIL` from environment variables. This enables custom deployments to configure their own super admin email without modifying source code.

- **`src/components/admin/AdminDashboard.tsx`**: Had a **wrong** hardcoded value `"admin@devpath.com"` — replaced with env var.
- **`src/context/AuthContext.tsx`**: Replaced hardcoded `'devpathind.community@gmail.com'` with env var + fallback to preserve existing behavior for the production deployment. Also fixed 3 remaining places that compared against the raw string instead of the `SUPER_ADMIN_EMAIL` constant.
- **`.env.example`**: Documented the new `NEXT_PUBLIC_SUPER_ADMIN_EMAIL` variable.

Fixes #224

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local testing
- [ ] Vercel Preview Deployment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact