### PR TITLE
fix: remove isMobile state and resize listener from FloatingParticles…

### DIFF
--- a/src/components/FloatingParticles.tsx
+++ b/src/components/FloatingParticles.tsx
@@ -5,16 +5,16 @@ import { useState, useEffect } from "react"
 export function FloatingParticles() {
     const [mounted, setMounted] = useState(false)
     const [particles, setParticles] = useState<Array<{ symbol: string, delay: number, duration: number, x: number, y: number, initialX: number, initialY: number }>>([])
-    const [isMobile, setIsMobile] = useState(false)
+    // const [isMobile, setIsMobile] = useState(false)
     const shouldReduceMotion = useReducedMotion()
 
     useEffect(() => {
         setMounted(true)
 
-        // Check if mobile
-        const checkMobile = () => setIsMobile(window.innerWidth < 768)
-        checkMobile()
-        window.addEventListener('resize', checkMobile)
+        // // Check if mobile
+        // const checkMobile = () => setIsMobile(window.innerWidth < 768)
+        // checkMobile()
+        // // window.addEventListener('resize', checkMobile)
 
         const particleConfig = [
             { symbol: "</>", delay: 0, duration: 15, x: 100, y: -100 },
@@ -25,8 +25,10 @@ export function FloatingParticles() {
             { symbol: "&&", delay: 5, duration: 19, x: -120, y: -100 },
         ]
 
-        // Use fewer particles on mobile for performance
-        const configToUse = isMobile ? particleConfig.slice(0, 3) : particleConfig
+        const isMobileDevice = window.innerWidth < 768
+        const configToUse = isMobileDevice
+            ? particleConfig.slice(0, 3)
+            : particleConfig
 
         setParticles(configToUse.map(p => ({
             ...p,
@@ -34,8 +36,7 @@ export function FloatingParticles() {
             initialY: Math.random() * 100
         })))
 
-        return () => window.removeEventListener('resize', checkMobile)
-    }, [isMobile])
+    }, [])
 
     // Don't render if user prefers reduced motion or not mounted
     if (!mounted || shouldReduceMotion) return null


### PR DESCRIPTION
// Changes Made

Fixes #260

## Problem
- `isMobile` state in useEffect dependency array caused particles to reset on every window resize
- `window.addEventListener('resize')` triggered unnecessary re-renders
- `willChange: 'transform'` on all particles consumed extra memory

## Fix 

**Removed:**
- `isMobile` state variable
- `resize` event listener
- `willChange: 'transform'` from particle styles
- `[isMobile]` dependency from useEffect

**Added:**
- `window.innerWidth` check inside useEffect
- Empty `[]` dependency array - runs only once
 
##Before
```ts
const [isMobile, setIsMobile] = useState(false)
window.addEventListener('resize', checkMobile)
}, [isMobile])
```
`
##After:
```
const isMobileDevice = window.innerWidth < 768
}, [])
```
##Video
https://github.com/user-attachments/assets/8b3b7c38-841e-46e4-add2-46986dca6c19

## Expected Impact
- No unnecessary re-renders on window resize
- Reduced memory usage
- Better performance on mobile

@Aditya948351 @devpathindcommunity-india