### PR TITLE
fix: add client-side fallback sorting for latest event query

### DIFF
--- a/src/components/home/LatestEventsHighlight.tsx
+++ b/src/components/home/LatestEventsHighlight.tsx
@@ -22,7 +22,6 @@ export default function LatestEventsHighlight({ className }: { className?: strin
                     orderBy('date', 'asc'),
                     limit(1)
                 );
-
                 const snapshot = await getDocs(q);
                 if (mounted && !snapshot.empty) {
                     const eventData = { id: snapshot.docs[0].id, ...snapshot.docs[0].data() };
@@ -30,6 +29,19 @@ export default function LatestEventsHighlight({ className }: { className?: strin
                 }
             } catch (error) {
                 console.error("Error fetching latest event:", error);
+
+                try {
+                    // Fallback: fetch and sort client-side
+                    const fallbackSnapshot = await getDocs(query(collection(db, 'events'),where('completed', '==', false))); 
+
+                    if (mounted && !fallbackSnapshot.empty) {
+                        const sortedEvents = fallbackSnapshot.docs.map((doc) => ({id: doc.id,...doc.data(),}))
+                        .sort((a: any, b: any) => new Date(a.date).getTime() - new Date(b.date).getTime());
+                        setEvent(sortedEvents[0]);
+                    }
+                } catch (fallbackError) {
+                    console.error("Fallback fetch failed:", fallbackError);
+                }
             } finally {
                 if (mounted) setLoading(false);
             }


### PR DESCRIPTION
## Description
Implemented graceful fallback handling for the latest events query in `LatestEventsHighlight.tsx`.

The component now falls back to fetching incomplete events without server-side ordering if the Firestore query fails and applies client-side sorting by date to ensure the nearest upcoming event is still displayed without breaking the UI.

Fixes #241 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## How Has This Been Tested?

* [x] Local testing
* [ ] Vercel Preview Deployment

Testing performed:

* Verified that the latest event renders correctly on the homepage under normal conditions
* Verified fallback logic by simulating query failure and ensuring client-side sorting still displays the nearest upcoming event

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] I have checked that the "DevPath India" branding remains intact
