### PR TITLE
feat: add character limit and countdown to bio textarea (#235)

### DIFF
--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -778,14 +778,20 @@ useEffect(() => {
                                     </div>
                                 </div>
                                 {aboutTab === 'write' ? (
-                                    <textarea
-                                        value={aboutContent}
-                                        onChange={(e) => setAboutContent(e.target.value)}
-                                        className="w-full min-h-[300px] p-4 bg-background border border-border rounded-lg font-mono text-sm"
-                                        placeholder="Markdown supported..."
-                                        name="aboutContent"
-                                        id="aboutContent"
-                                    />
+                                    <div>
+                                        <textarea
+                                            value={aboutContent}
+                                            onChange={(e) => setAboutContent(e.target.value)}
+                                            maxLength={500}
+                                            className="w-full min-h-[300px] p-4 bg-background border border-border rounded-lg font-mono text-sm"
+                                            placeholder="Markdown supported..."
+                                            name="aboutContent"
+                                            id="aboutContent"
+                                        />
+                                        <p className={`text-xs text-right mt-1 ${aboutContent.length >= 480 ? 'text-red-500' : 'text-muted-foreground'}`}>
+                                            {500 - aboutContent.length} / 500 characters remaining
+                                        </p>
+                                    </div>
                                 ) : (
                                     <div className="min-h-[300px] p-4 bg-background border border-border rounded-lg">
                                         <div className="markdown-body">


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Added a maximum character limit of 500 to the biography text area in the `UserProfile` component to prevent large document sizes and database bloat in Firestore. 
Additionally, implemented a dynamic character countdown below the text area that updates as the user types and turns red when only 20 characters are left (480/500).

Fixes #235 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
- [x] Local testing
- [ ] Vercel Preview Deployment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact