### PR TITLE
fix(quiz): resolve double-submission and XP inflation race condition …

### DIFF
--- a/src/components/resources/QuizComponent.tsx
+++ b/src/components/resources/QuizComponent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import confetti from "canvas-confetti";
 import { Trophy, Zap, Target, Lightbulb, CheckCircle2, XCircle } from "lucide-react";
 import styles from "./QuizComponent.module.css";
@@ -32,7 +32,7 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
 
   // Reset state if quizId changes
   useEffect(() => {
@@ -44,7 +44,9 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
   }, [quizId]);
 
   const handleQuizSubmit = async () => {
-    if (isSubmitting) return;
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
+    
     const current = questions[currentQuestion];
     setShowFeedback(true);
 
@@ -60,10 +62,10 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
       if (currentQuestion + 1 < questions.length) {
         setCurrentQuestion(currentQuestion + 1);
         setSelectedAnswer("");
+        isSubmittingRef.current = false;
       } else {
         // Quiz completed
         setShowResult(true);
-        setIsSubmitting(true);
 
         const isPerfect = updatedScore === questions.length;
         const passed = updatedScore >= Math.ceil(questions.length * 0.7);
@@ -103,7 +105,7 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
         } catch (error) {
           console.error("Failed to update quiz progress:", error);
         } finally {
-          setIsSubmitting(false);
+          isSubmittingRef.current = false;
         }
       }
     }, 1200);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR fixes the race condition in `QuizComponent.tsx` that allowed users to spam or double-click the submit/finish button, resulting in multiple API calls and inflated XP points. 

I replaced the asynchronous `isSubmitting` React state (`useState`) with a synchronous `isSubmittingRef` lock using `useRef`. This ensures the submission logic is immediately locked upon the first click, completely preventing duplicate executions.

Fixes #231

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
- [x] Local testing
- [ ] Vercel Preview Deployment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact