### PR TITLE
fix: add alphanumeric and length validation for mobile field (#232)

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -52,6 +52,12 @@ export default function SignupPage() {
     const handleSignup = async (e: React.FormEvent) => {
         e.preventDefault();
         setError('');
+
+        if (!/^\d{10}$/.test(mobile)) {
+            setError('Please enter a valid 10-digit mobile number.');
+            return;
+        }
+
         setLoading(true);
 
         try {
@@ -221,9 +227,11 @@ export default function SignupPage() {
                                     <input
                                         type="tel"
                                         value={mobile}
-                                        onChange={(e) => setMobile(e.target.value)}
+                                        onChange={(e) => setMobile(e.target.value.replace(/\D/g, ''))}
                                         className="w-full pl-10 pr-3 py-2 bg-background border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                                         placeholder="98765 43210"
+                                        pattern="[0-9]{10}"
+                                        maxLength={10}
                                         required
                                     />
                                 </div>


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR adds missing alphanumeric and length validations to the mobile number input field on the Signup page. 
- Prevents typing alphabetical letters or symbols by automatically stripping non-numeric characters using regex.
- Enforces a 10-digit length constraint using `maxLength` and standard HTML `pattern`.
- Adds a strict submission validation to prevent saving invalid strings into the Firestore database.

Fixes #232

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
- [x] Local testing
- [ ] Vercel Preview Deployment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact