### PR TITLE
fix: prevent flash of incorrect theme on page load (Issue #261)

### DIFF
--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -9,6 +9,33 @@ import Button from "@/components/ui/Button"
 export function ThemeToggle() {
     const { setTheme, theme } = useTheme()
 
+    // Fix (Issue #261): Track hydration to prevent flash of incorrect theme.
+    // Before Next.js hydration completes, `theme` is undefined so the Sun/Moon
+    // icons render in the wrong state, causing a visible flash on page load.
+    const [mounted, setMounted] = React.useState(false)
+
+    // useEffect only runs on the client, so `mounted` becomes true only after
+    // hydration — at which point the correct saved theme is known.
+    React.useEffect(() => {
+        setMounted(true)
+    }, [])
+
+    // Render a same-sized disabled placeholder before hydration to avoid layout
+    // shift and prevent theme-dependent icons from flickering.
+    if (!mounted) {
+        return (
+            <Button
+                variant="ghost"
+                disabled
+                aria-hidden="true"
+                className="relative h-9 w-9 rounded-full border border-white/10 bg-white/5 p-0 flex items-center justify-center"
+            >
+                <span className="sr-only">Toggle theme</span>
+            </Button>
+        )
+    }
+
+    // After hydration, theme is resolved — render the real toggle safely.
     return (
         <Button
             variant="ghost"


### PR DESCRIPTION
## Description

Fixes #261

The `ThemeToggle` component was rendering Sun/Moon icons before Next.js hydration completed. At that point `theme` is `undefined` (from `next-themes`), so the icons briefly appeared in the wrong state — causing a visible light-mode flash for users who had dark mode saved.

**Fix:** Added a `mounted` state that becomes `true` only after client-side hydration via `useEffect`. Before mounting, a same-sized disabled placeholder button is rendered so there is no layout shift and no theme-dependent icons flash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Local testing
  1. Set theme preference to Dark Mode
  2. Hard refresh the page
  3. Verified no light-mode flash appears in the Navbar ThemeToggle

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact

