### PR TITLE
# fix(ap): Replace unstyled `Unauthorized` screen with premium restricted-access UI

### DIFF
--- a/src/app/ap/page.tsx
+++ b/src/app/ap/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/navigation';
-import { Shield, Key, Lock } from 'lucide-react';
+import { Shield, Key, Lock, ArrowLeft, Home } from 'lucide-react';
 import { doc, getDoc, setDoc, addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { db, auth } from '@/lib/firebase';
@@ -96,7 +96,57 @@ export default function SuperAdminLogin() {
     }
 
     if (user.email !== SUPER_ADMIN_EMAIL) {
-        return <div className="min-h-screen flex items-center justify-center">Unauthorized</div>;
+        return (
+            <div className="min-h-screen bg-black flex flex-col items-center justify-center p-4">
+                {/* Ambient glow */}
+                <div className="absolute inset-0 overflow-hidden pointer-events-none">
+                    <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-red-900/10 rounded-full blur-3xl" />
+                </div>
+
+                <div className="relative max-w-md w-full bg-zinc-900/90 border border-red-900/40 rounded-2xl p-10 shadow-2xl backdrop-blur-sm text-center">
+                    {/* Icon badge */}
+                    <div className="w-20 h-20 bg-red-500/10 border border-red-500/20 rounded-full flex items-center justify-center mx-auto mb-6">
+                        <Lock size={36} className="text-red-500" strokeWidth={1.5} />
+                    </div>
+
+                    {/* Header */}
+                    <h1 className="text-2xl font-bold text-white mb-2 tracking-tight">
+                        Access Denied
+                    </h1>
+                    <div className="inline-flex items-center gap-2 bg-red-500/10 border border-red-500/20 text-red-400 text-xs font-semibold px-3 py-1 rounded-full mb-5">
+                        <Shield size={11} />
+                        Restricted Area
+                    </div>
+
+                    <p className="text-zinc-400 text-sm leading-relaxed mb-8">
+                        You do not have the required privileges to access this portal.
+                        This area is reserved for authorized Super Admin accounts only.
+                        All unauthorized access attempts are logged.
+                    </p>
+
+                    {/* Divider */}
+                    <div className="border-t border-zinc-800 mb-8" />
+
+                    {/* Actions */}
+                    <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                        <button
+                            onClick={() => router.back()}
+                            className="flex items-center justify-center gap-2 px-5 py-2.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
+                        >
+                            <ArrowLeft size={15} />
+                            Go Back
+                        </button>
+                        <button
+                            onClick={() => router.push('/')}
+                            className="flex items-center justify-center gap-2 px-5 py-2.5 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
+                        >
+                            <Home size={15} />
+                            Return Home
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
     }
 
     if (isAuthenticated) {


### PR DESCRIPTION
﻿Fixes #229

# fix(ap): Replace unstyled `Unauthorized` screen with premium restricted-access UI #229   ## Summary  Replaces a raw, completely unstyled `"Unauthorized"` string rendered on a blank white screen at `/ap` with a fully designed restricted-access card that matches the dark premium aesthetic of the rest of the admin portal.  ---  ## Problem  When a logged-in member without super-admin privileges manually navigated to `/ap`, the following was returned:  ```tsx // BEFORE ΓÇö bare, unstyled return <div className="min-h-screen flex items-center justify-center">Unauthorized</div>; ```  This rendered plain black text on a white background ΓÇö a jarring break from the rest of the site's dark zinc/black design system and completely inconsistent with the existing `!user` guard just above it, which already used a proper styled layout.  ---  ## Fix  ```tsx // AFTER ΓÇö styled restricted-access card return (   <div className="min-h-screen bg-black flex flex-col items-center justify-center p-4">     {/* Ambient glow backdrop */}     <div className="absolute inset-0 overflow-hidden pointer-events-none">       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2                       w-[500px] h-[500px] bg-red-900/10 rounded-full blur-3xl" />     </div>      <div className="relative max-w-md w-full bg-zinc-900/90 border border-red-900/40                     rounded-2xl p-10 shadow-2xl backdrop-blur-sm text-center">       {/* Lock icon badge */}       <div className="w-20 h-20 bg-red-500/10 border border-red-500/20 rounded-full                       flex items-center justify-center mx-auto mb-6">         <Lock size={36} className="text-red-500" strokeWidth={1.5} />       </div>        <h1 className="text-2xl font-bold text-white mb-2 tracking-tight">Access Denied</h1>        {/* Restricted Area pill badge */}       <div className="inline-flex items-center gap-2 bg-red-500/10 border border-red-500/20                       text-red-400 text-xs font-semibold px-3 py-1 rounded-full mb-5">         <Shield size={11} /> Restricted Area       </div>        <p className="text-zinc-400 text-sm leading-relaxed mb-8">         You do not have the required privileges to access this portal.         This area is reserved for authorized Super Admin accounts only.         All unauthorized access attempts are logged.       </p>        <div className="border-t border-zinc-800 mb-8" />        {/* Navigation actions */}       <div className="flex flex-col sm:flex-row gap-3 justify-center">         <button onClick={() => router.back()} className="...">           <ArrowLeft size={15} /> Go Back         </button>         <button onClick={() => router.push('/')} className="...">           <Home size={15} /> Return Home         </button>       </div>     </div>   </div> ); ```  ---  ## Changes  ### `src/app/ap/page.tsx`  | # | Change | Detail | |---|--------|--------| | 1 | Added `ArrowLeft`, `Home` to lucide imports | Required for navigation button icons | | 2 | Replaced raw `Unauthorized` div | Full styled restricted-access card | | 3 | Ambient blur glow backdrop | Subtle `red-900/10` radial blur matches admin portal dark atmosphere | | 4 | `Lock` icon badge | Reinforces visual meaning ΓÇö replacing the generic text | | 5 | "Restricted Area" pill badge | Consistent with status pill patterns used elsewhere on the site | | 6 | Description text | Informs the user clearly and mentions logging, acting as a soft deterrent | | 7 | `Go Back` + `Return Home` buttons | Gives users a clear exit path instead of leaving them stranded |  ---  ## Design Consistency  The new card deliberately mirrors the existing `!user` guard layout already in the same file ΓÇö same `bg-black` canvas, same `zinc-900` card, same `red-500` accent palette, same `shadow-2xl` depth, and same button style. The page now reads as a cohesive, intentional design rather than an overlooked edge case.  ---  ## Steps to Reproduce (before fix)  1. Log in with a standard member account. 2. Navigate manually to `/ap`. 3. Observe: plain white screen, black text reading "Unauthorized".  ## Verification (after fix)  1. Log in with a standard member account and navigate to `/ap`. 2. Observe: dark full-screen restricted-access card with Lock icon, "Access Denied" heading,    "Restricted Area" pill badge, descriptive warning text, and navigation buttons. 3. Click **Go Back** ΓÇö browser navigates to the previous page. 4. Click **Return Home** ΓÇö navigates to `/`. 5. Log in as Super Admin and navigate to `/ap` ΓÇö admin portal loads as expected, no regressions.  ---  ## Impact  - **No functional changes** ΓÇö auth logic and admin access are completely unaffected. - **UX:** Eliminates the jarring white-screen break for any non-admin who stumbles onto `/ap`. - **Security posture:** Soft deterrent message ("access attempts are logged") adds a psychological barrier without revealing system internals. 
