### PR TITLE
docs: add folder structure section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 - [🚀 Features](#-features)
 - [🛠️ Tech Stack](#️-tech-stack)
+- [📁 Folder Structure](#-folder-structure)
 - [📸 Screenshots](#-screenshots)
 - [🏁 Getting Started](#-getting-started)
   - [Prerequisites](#prerequisites)
@@ -55,6 +56,38 @@ This project leverages a modern and powerful technology stack:
 - **Animations**: [Framer Motion](https://www.framer.com/motion/) & [GSAP](https://greensock.com/gsap/)
 - **Icons**: [Lucide React](https://lucide.dev/)
 - **Linting**: [ESLint](https://eslint.org/)
+
+## 📁 Folder Structure
+
+A quick overview of the project's organization to help new contributors navigate the codebase easily.
+
+```
+DevPath-Web/
+├── .github/               # GitHub workflows, PR & issue templates
+├── public/                # Static assets (images, icons, fonts, logo)
+├── scripts/               # Utility and automation scripts
+├── src/                   # Main source code
+│   ├── app/               # Next.js App Router — pages, layouts & routing
+│   ├── assets/            # Project assets (SVGs, illustrations)
+│   ├── components/        # Reusable UI components used across pages
+│   ├── config/            # App-level configuration and constants
+│   ├── context/           # React Context API providers (global state)
+│   ├── data/              # Static data, mock data & content constants
+│   ├── hooks/             # Custom React hooks for shared logic
+│   ├── lib/               # Third-party library setups (Firebase, etc.)
+│   └── utils/             # Helper functions and utility methods
+├── .env.example           # Environment variables template
+├── .env.local             # Local environment variables (git-ignored)
+├── firebase.json          # Firebase Hosting & services configuration
+├── firestore.rules        # Firestore security rules
+├── firestore.indexes.json # Firestore composite indexes
+├── next.config.ts         # Next.js configuration
+├── tailwind.config.ts     # Tailwind CSS configuration
+├── tsconfig.json          # TypeScript compiler configuration
+├── postcss.config.js      # PostCSS configuration
+└── eslint.config.mjs      # ESLint rules and configuration
+```
+
 
 ## 📸 Screenshots
 


### PR DESCRIPTION
Fix #357 

## What does this PR do?
Adds a well-structured and descriptive Folder Structure section 
to the README to help new contributors navigate the codebase easily.

## Changes Made
- Added `📁 Folder Structure` section to README.md
- Added entry in the Table of Contents
- Documented all top-level folders and important config files 
  with clear descriptions
- Covered all `src/` subdirectories (app, assets, components, 
  config, context, data, hooks, lib, utils)

## Why?
New contributors often struggle to understand where to start. 
This section gives them a clear map of the project structure 
at a glance.
