### PR TITLE
fix(#348): remove broad allow write from leaderboard Firestore rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -113,12 +113,20 @@ service cloud.firestore {
     }
 
     // Leaderboard collection
+    // The broad allow write clause has been removed. It was evaluated first by
+    // Firestore's OR logic, making the field-restricted allow update below it
+    // completely unreachable, and letting any owner set arbitrary point values.
     match /leaderboard/{userId} {
       allow read: if true;
-      allow write: if (request.auth != null && request.auth.uid == userId) || isSuperAdmin(); // Owner or Super Admin can write
-      allow update: if request.auth != null && request.auth.uid == userId && (
-        (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points']))
-      );
+
+      // Only a superadmin (backend / Admin SDK) may create or delete entries.
+      allow create, delete: if isSuperAdmin();
+
+      // Owners may only touch the 'points' field. All other leaderboard
+      // mutations must go through the trusted backend.
+      allow update: if request.auth != null
+        && request.auth.uid == userId
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points']);
     }
 
     // Resources collection


### PR DESCRIPTION
## Summary

Fixes #348

The `leaderboard/{userId}` Firestore security rule had both an `allow write` and a field-restricted `allow update` clause. Firestore evaluates `allow` statements with OR logic, so the broader `allow write` always matched first for document owners, making `allow update` completely unreachable. This let any authenticated user write arbitrary values to their own `points` field directly via the Firestore client SDK.

## Root cause

```js
// Before: allow write evaluates first; allow update is never reached
match /leaderboard/{userId} {
  allow read: if true;
  allow write: if (request.auth != null && request.auth.uid == userId) || isSuperAdmin();
  allow update: if request.auth != null && request.auth.uid == userId && (
    request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points'])
  );
}
```

## Fix

```js
// After: explicit per-operation rules; no overlapping write catch-all
match /leaderboard/{userId} {
  allow read: if true;

  // Only a superadmin (backend / Admin SDK) may create or delete entries.
  allow create, delete: if isSuperAdmin();

  // Owners may only touch the points field.
  allow update: if request.auth != null
    && request.auth.uid == userId
    && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points']);
}
```

## Changes

- `firestore.rules`: removed the `allow write` clause from `leaderboard/{userId}` and replaced it with explicit `allow create, delete: if isSuperAdmin()`.

## Security impact

- Before: any signed-in user could call `db.doc('leaderboard/<uid>').set({ points: 99999 })` and succeed.
- After: client-side writes are limited to updating the `points` field only; create and delete operations require superadmin privileges.

## Test plan

- [ ] As a regular authenticated user, attempt to set an arbitrary `points` value via the Firestore client SDK and confirm it is rejected.
- [ ] As a regular authenticated user, attempt to delete your leaderboard document and confirm it is rejected.
- [ ] Confirm the leaderboard still displays correctly in the app (backend writes via Admin SDK are unaffected by these rules).
- [ ] Confirm a superadmin can still create and delete leaderboard entries as needed.