### PR TITLE
chore: add standard .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 4
+
+[*.{json,md,yml,yaml,css,scss}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Closes #370. This PR adds a standard \.editorconfig\ file for consistent formatting across different editors.