### PR TITLE
fix(#349): deny self-writes on members badges subcollection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -85,9 +85,12 @@ service cloud.firestore {
       }
 
       // Badges Subcollection
+      // Badge grants must come from trusted backend (Cloud Functions / Admin SDK).
+      // Self-writes are intentionally denied to prevent users from awarding
+      // themselves arbitrary badges without meeting the criteria.
       match /badges/{badgeId} {
         allow read: if true;
-        allow write: if isSuperAdmin() || (request.auth != null && request.auth.uid == userId);
+        allow write: if isSuperAdmin();
       }
 
       // GitHub Repos Subcollection


### PR DESCRIPTION
## What and Why

Closes #349

The `members/{userId}/badges/{badgeId}` Firestore rule previously allowed any authenticated user to write badge documents to their own subcollection:

```
allow write: if isSuperAdmin() || (request.auth != null && request.auth.uid == userId);
```

Because badge eligibility logic (`determineBadges`) runs entirely client-side, this rule let any signed-in user award themselves arbitrary badges (including `early-adopter`, `streak-7`, and others) by sending a direct Firestore `set` call without meeting any criteria.

## Change

Removed the `request.auth.uid == userId` branch so the rule becomes:

```
allow write: if isSuperAdmin();
```

Badge grants must originate from trusted backend code (Cloud Functions or Admin SDK) that verifies criteria before writing. The `allow read` condition is unchanged.

## Files Changed

- `firestore.rules` (1 line changed in the `members/{userId}/badges/{badgeId}` block)

## Test Plan

- [ ] Verify that a regular authenticated user can no longer write to `members/<uid>/badges/<anyId>` via the Firestore client SDK.
- [ ] Verify that super admin writes (via Admin SDK or the super admin account) still succeed.
- [ ] Confirm that badge reads remain public (no regression on badge display pages).

## GSSoC

program: gssoc