### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig: https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.{ts,tsx}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Fix #370 

## What does this PR do?
Adds a standard .editorconfig file to the project root to ensure 
consistent code formatting across different IDEs and editors.

## Changes Made
- Created .editorconfig file in the project root
- Set UTF-8 charset and LF line endings
- Configured 2-space indentation for all files
- Added specific rules for .md, .json, .yml, .ts, .tsx files
- Enabled trim trailing whitespace and insert final newline

## Why?
Without a standard .editorconfig, different developers using 
different IDEs (VS Code, WebStorm, etc.) may produce inconsistent 
formatting, leading to unnecessary diffs in PRs.
