### PR TITLE
fix: hide X-Powered-By header via Firebase hosting config

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,6 +16,17 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "X-Powered-By",
+            "value": ""
+          }
+        ]
+      }
     ]
   },
   "firestore": {


### PR DESCRIPTION
Fix #361 

## What does this PR do?
Hides the X-Powered-By header to prevent leaking technology 
stack details to potential attackers.

## Changes Made
- Added headers configuration in `firebase.json` to remove 
  the X-Powered-By header from all responses

## Research
This project uses Next.js with `output: 'export'` deployed 
on Firebase Hosting (static). Since there is no Express 
backend, middleware-based solutions won't work here.
Configuring headers directly in `firebase.json` is the 
correct approach for this setup.

## Why?
Exposing the X-Powered-By header reveals the technology stack 
to attackers, making it easier to target known vulnerabilities.
