### PR TITLE
Fix: whitespace-only biographies from being saved

### DIFF
--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -229,9 +229,9 @@ useEffect(() => {
         setIsSaving(true);
         try {
             const safeSocialLinks = sanitizeSocialLinks(socialLinks);
-
+            const trimmedAbout = aboutContent.trim();
             await updateUserProfile({
-                aboutMarkdown: aboutContent,
+                aboutMarkdown: trimmedAbout,
                 ...safeSocialLinks
             });
             setSocialLinks(safeSocialLinks);


### PR DESCRIPTION
Fixes #234 

## Summary

Fixes an issue where users could save biographies containing only whitespace characters.

### Changes

* Trim biography content before saving.
* Prevent whitespace-only values from being stored in Firestore.

### Testing

* Verified normal biography text (e.g. "abc") saves correctly.
* Verified whitespace-only input is trimmed to an empty string before saving.

Thank you for your time and review. The change is limited to the assigned issue and has been tested with both normal and whitespace-only biography inputs.