### PR TITLE
chore: remove unused CSS variables and dead code from globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,8 +47,6 @@
 
     /* Gradients */
     --gradient-primary: linear-gradient(135deg, var(--accent-cyan), var(--accent-purple));
-    --gradient-secondary: linear-gradient(135deg, var(--accent-purple), var(--accent-pink));
-    --gradient-glow: radial-gradient(circle at center, rgba(0, 212, 255, 0.15), transparent 70%);
 
     /* Glassmorphism Premium */
     /* Glassmorphism Premium (Light) */
@@ -58,14 +56,6 @@
     --glass-blur: 20px;
     --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.1);
     --icon-glow: rgba(0, 0, 0, 0.1);
-
-    /* Spacing */
-    --spacing-xs: 4px;
-    --spacing-sm: 8px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-xl: 32px;
-    --spacing-xxl: 48px;
 
     /* Animation */
     --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
@@ -163,23 +153,7 @@ a {
   text-decoration: none;
 }
 
-/* Premium Utilities */
-.glass {
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur));
-  -webkit-backdrop-filter: blur(var(--glass-blur));
-  border: 1px solid var(--glass-border);
-  box-shadow: var(--glass-shadow);
-}
 
-.text-gradient {
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-size: 200% auto;
-  animation: gradient-flow 5s linear infinite;
-}
 
 .container {
   max-width: 1400px;
@@ -187,48 +161,6 @@ a {
   padding: 0 24px;
 }
 
-/* Animations */
-@keyframes gradient-flow {
-  0% {
-    background-position: 0% 50%;
-  }
-
-  50% {
-    background-position: 100% 50%;
-  }
-
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
-@keyframes float {
-  0% {
-    transform: translateY(0px);
-  }
-
-  50% {
-    transform: translateY(-10px);
-  }
-
-  100% {
-    transform: translateY(0px);
-  }
-}
-
-@keyframes pulse-glow {
-  0% {
-    box-shadow: 0 0 0 0 rgba(0, 212, 255, 0.4);
-  }
-
-  70% {
-    box-shadow: 0 0 0 10px rgba(0, 212, 255, 0);
-  }
-
-  100% {
-    box-shadow: 0 0 0 0 rgba(0, 212, 255, 0);
-  }
-}
 
 /* Scrollbar */
 ::-webkit-scrollbar {
@@ -344,8 +276,4 @@ a {
 
 .markdown-body [width] {
   width: auto;
-}
-/* GSSoC'26 Issue #31: Fix abrupt page snap when navigating mobile anchor links */
-html {
-  scroll-behavior: smooth !important;
 }


### PR DESCRIPTION
Fix #371 

## What does this PR do?
Removes unused CSS variables, dead code, and duplicate styles 
from globals.css to keep the codebase clean and maintainable.

## Changes Made
- Removed unused spacing variables (`--spacing-xs` to `--spacing-xxl`)
- Removed unused gradient variables (`--gradient-secondary`, `--gradient-glow`)
- Removed unused `.glass` utility class
- Removed unused `.text-gradient` utility class
- Removed unused `@keyframes gradient-flow`
- Removed duplicate `@keyframes float` (already defined in `Translate.module.css`)
- Removed unused `@keyframes pulse-glow`
- Removed duplicate `scroll-behavior: smooth` (already defined in `html, body`)

## Verification
All removed classes and variables were cross-checked across 
the entire `src/` directory to confirm they are not used 
anywhere in the codebase.

## Why?
Dead code increases file size and makes maintenance harder. 
Removing unused styles keeps the codebase clean and improves 
readability.