### PR TITLE
Add dark mode preference sync with user account

### DIFF
--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -5,9 +5,14 @@ import { Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
 
 import Button from "@/components/ui/Button"
+import { useAuth } from "@/context/AuthContext"
+
+type ThemePreference = "light" | "dark"
 
 export function ThemeToggle() {
-    const { setTheme, theme } = useTheme()
+    const { setTheme, theme, resolvedTheme } = useTheme()
+    const { user, updateUserProfile } = useAuth()
+    const pendingThemeRef = React.useRef<ThemePreference | null>(null)
 
     // Fix (Issue #261): Track hydration to prevent flash of incorrect theme.
     // Before Next.js hydration completes, `theme` is undefined so the Sun/Moon
@@ -19,6 +24,46 @@ export function ThemeToggle() {
     React.useEffect(() => {
         setMounted(true)
     }, [])
+
+    React.useEffect(() => {
+        if (!mounted) return
+
+        const savedTheme = user?.preferences?.theme
+
+        if (pendingThemeRef.current) {
+            if (savedTheme === pendingThemeRef.current) {
+                pendingThemeRef.current = null
+            }
+            return
+        }
+
+        if (!savedTheme || savedTheme === resolvedTheme) return
+
+        setTheme(savedTheme)
+    }, [mounted, resolvedTheme, setTheme, user?.preferences?.theme])
+
+    const handleToggle = async () => {
+        const currentTheme = (resolvedTheme || theme) === "light" ? "light" : "dark"
+        const nextTheme: ThemePreference = currentTheme === "light" ? "dark" : "light"
+
+        setTheme(nextTheme)
+
+        if (!user) return
+
+        pendingThemeRef.current = nextTheme
+
+        try {
+            await updateUserProfile({
+                preferences: {
+                    ...user.preferences,
+                    theme: nextTheme
+                }
+            })
+        } catch (error) {
+            pendingThemeRef.current = null
+            console.error("Error saving theme preference:", error)
+        }
+    }
 
     // Render a same-sized disabled placeholder before hydration to avoid layout
     // shift and prevent theme-dependent icons from flickering.
@@ -37,9 +82,9 @@ export function ThemeToggle() {
 
     // After hydration, theme is resolved — render the real toggle safely.
     return (
-        <Button aria-label="Action button" 
+        <Button aria-label="Toggle theme"
             variant="ghost"
-            onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+            onClick={handleToggle}
             className="relative h-9 w-9 rounded-full border border-white/10 bg-white/5 hover:bg-white/10 hover:text-white transition-colors p-0 flex items-center justify-center"
         >
             <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0 text-yellow-400" />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -35,6 +35,9 @@ interface User {
         isPublic?: boolean;
         showInCommunity?: boolean;
     };
+    preferences?: {
+        theme?: 'light' | 'dark';
+    };
     points?: number;
     achievements?: string[]; // Array of achievement IDs
     completedQuizzes?: string[]; // Array of completed quiz IDs
@@ -189,6 +192,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                                     showRewards: true,
                                     isPublic: true,
                                     showInCommunity: true
+                                },
+                                preferences: {
+                                    theme: 'dark'
                                 },
                                 githubStats: {
                                     connected: false,


### PR DESCRIPTION
## Description

Implemented synchronization of the dark mode preference with the user's account settings. The selected theme is now persisted through the user profile, ensuring that theme preferences remain consistent across sessions and devices.

Fixes #375

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## How Has This Been Tested?

* [x] Local testing
* [ ] Vercel Preview Deployment

### Tests Performed

* Verified theme toggle functionality.
* Confirmed theme preference persists after page refresh.
* Confirmed saved preference is loaded correctly on login.
* Tested switching between light and dark modes multiple times.

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or errors
* [x] I have checked that the "DevPath India" branding remains intact
