### PR TITLE
Fix race condition in quiz submission state updates

### DIFF
--- a/src/components/resources/QuizComponent.tsx
+++ b/src/components/resources/QuizComponent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import confetti from "canvas-confetti";
 import { Trophy, Zap, Target, Lightbulb, CheckCircle2, XCircle } from "lucide-react";
 import styles from "./QuizComponent.module.css";
@@ -18,6 +18,62 @@ export interface QuizComponentProps {
   title?: string;
 }
 
+type QuizState = {
+  currentQuestion: number;
+  selectedAnswer: string;
+  score: number;
+  showResult: boolean;
+  showFeedback: boolean;
+};
+
+type QuizAction =
+  | { type: "reset" }
+  | { type: "selectAnswer"; answer: string }
+  | { type: "submitAnswer"; isCorrect: boolean }
+  | { type: "nextQuestion" }
+  | { type: "completeQuiz" };
+
+const initialQuizState: QuizState = {
+  currentQuestion: 0,
+  selectedAnswer: "",
+  score: 0,
+  showResult: false,
+  showFeedback: false,
+};
+
+function quizReducer(state: QuizState, action: QuizAction): QuizState {
+  switch (action.type) {
+    case "reset":
+      return initialQuizState;
+    case "selectAnswer":
+      return {
+        ...state,
+        selectedAnswer: action.answer,
+      };
+    case "submitAnswer":
+      return {
+        ...state,
+        score: action.isCorrect ? state.score + 1 : state.score,
+        showFeedback: true,
+      };
+    case "nextQuestion":
+      return {
+        ...state,
+        currentQuestion: state.currentQuestion + 1,
+        selectedAnswer: "",
+        showFeedback: false,
+      };
+    case "completeQuiz":
+      return {
+        ...state,
+        showFeedback: false,
+        showResult: true,
+      };
+    default:
+      return state;
+  }
+}
+
 /**
  * QuizComponent renders an interactive quiz interface.
  * On completion, it calculates the user's score and awards gamification XP
@@ -27,11 +83,7 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
   const { addXp } = useGamification();
   const { user, updateUserProfile, awardPoints } = useAuth();
 
-     const [currentQuestion, setCurrentQuestion] = useState(0);
-  const [selectedAnswer, setSelectedAnswer] = useState("");
-  const [score, setScore] = useState(0);
-  const [showResult, setShowResult] = useState(false);
-  const [showFeedback, setShowFeedback] = useState(false);
+  const [quizState, dispatchQuiz] = useReducer(quizReducer, initialQuizState);
   const isSubmittingRef = useRef(false);
 
   // Ref to track the in-flight feedback timer so it can be cancelled on unmount
@@ -45,12 +97,7 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
       timerRef.current = null;
     }
     
-    // Crucial Bug Patch: Force synchronized state updates to prevent out-of-order execution (#376)
-    setCurrentQuestion(() => 0);
-    setSelectedAnswer(() => "");
-    setScore(() => 0);
-    setShowResult(() => false);
-    setShowFeedback(() => false);
+    dispatchQuiz({ type: "reset" });
     isSubmittingRef.current = false;
   }, [quizId]); // Ensure dependency array balances tracking transitions cleanly
 
@@ -68,26 +115,23 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
     if (isSubmittingRef.current) return;
     isSubmittingRef.current = true;
     
-    const current = questions[currentQuestion];
-    setShowFeedback(true);
+    const questionIndex = quizState.currentQuestion;
+    const current = questions[questionIndex];
+    const isCorrect = quizState.selectedAnswer === current.answer;
+    const updatedScore = quizState.score + (isCorrect ? 1 : 0);
+    const isLastQuestion = questionIndex + 1 >= questions.length;
 
-    let updatedScore = score;
-    if (selectedAnswer === current.answer) {
-      updatedScore += 1;
-      setScore(updatedScore);
-    }
+    dispatchQuiz({ type: "submitAnswer", isCorrect });
 
     timerRef.current = setTimeout(async () => {
       timerRef.current = null;
-      setShowFeedback(false);
 
-      if (currentQuestion + 1 < questions.length) {
-        setCurrentQuestion(currentQuestion + 1);
-        setSelectedAnswer("");
+      if (!isLastQuestion) {
+        dispatchQuiz({ type: "nextQuestion" });
         isSubmittingRef.current = false;
       } else {
         // Quiz completed
-        setShowResult(true);
+        dispatchQuiz({ type: "completeQuiz" });
 
         const isPerfect = updatedScore === questions.length;
         const passed = updatedScore >= Math.ceil(questions.length * 0.7);
@@ -153,9 +197,9 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
     }, 250);
   };
 
-  if (showResult) {
-    const isPerfect = score === questions.length;
-    const passed = score >= Math.ceil(questions.length * 0.7);
+  if (quizState.showResult) {
+    const isPerfect = quizState.score === questions.length;
+    const passed = quizState.score >= Math.ceil(questions.length * 0.7);
 
     return (
       <div className={styles.resultContainer}>
@@ -163,7 +207,7 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
           Quiz Completed <Trophy size={28} className="inline-block text-yellow-500 mb-1" />
         </h2>
         <p className={styles.resultScore}>
-          Your Score: {score} / {questions.length}
+          Your Score: {quizState.score} / {questions.length}
         </p>
 
         {isPerfect ? (
@@ -184,10 +228,7 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
           <button aria-label="Action button" 
             className={styles.retryButton}
             onClick={() => {
-              setCurrentQuestion(0);
-              setSelectedAnswer("");
-              setScore(0);
-              setShowResult(false);
+              dispatchQuiz({ type: "reset" });
             }}
           >
             Retake Quiz
@@ -202,14 +243,14 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
     );
   }
 
-  const current = questions[currentQuestion];
+  const current = questions[quizState.currentQuestion];
 
   return (
     <div className={styles.quizContainer}>
       <div className={styles.quizHeader}>
         <h3 className={styles.quizTitle}>{title}</h3>
         <span className={styles.quizProgress}>
-          Question {currentQuestion + 1} / {questions.length}
+          Question {quizState.currentQuestion + 1} / {questions.length}
         </span>
       </div>
 
@@ -217,7 +258,7 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
       <div className={styles.progressBarContainer}>
         <div 
           className={styles.progressBarFill} 
-          style={{ width: `${((currentQuestion) / questions.length) * 100}%` }}
+          style={{ width: `${((quizState.currentQuestion) / questions.length) * 100}%` }}
         />
       </div>
 
@@ -226,13 +267,13 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
 
         <div className={styles.optionsContainer}>
           {current.options.map((option) => {
-            const isSelected = selectedAnswer === option;
+            const isSelected = quizState.selectedAnswer === option;
             const isCorrect = option === current.answer;
             
             let optionClass = styles.optionButton;
             if (isSelected) optionClass += ` ${styles.selected}`;
             
-            if (showFeedback) {
+            if (quizState.showFeedback) {
               if (isCorrect) optionClass += ` ${styles.correct}`;
               else if (isSelected) optionClass += ` ${styles.incorrect}`;
             }
@@ -241,8 +282,8 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
               <button aria-label="Action button" 
                 key={option}
                 className={optionClass}
-                disabled={showFeedback}
-                onClick={() => setSelectedAnswer(option)}
+                disabled={quizState.showFeedback}
+                onClick={() => dispatchQuiz({ type: "selectAnswer", answer: option })}
               >
                 {option}
               </button>
@@ -250,9 +291,9 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
           })}
         </div>
 
-        {showFeedback && (
-          <div className={`${styles.feedbackText} ${selectedAnswer === current.answer ? styles.feedbackCorrect : styles.feedbackIncorrect}`}>
-            {selectedAnswer === current.answer ? (
+        {quizState.showFeedback && (
+          <div className={`${styles.feedbackText} ${quizState.selectedAnswer === current.answer ? styles.feedbackCorrect : styles.feedbackIncorrect}`}>
+            {quizState.selectedAnswer === current.answer ? (
               <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>Correct Answer <CheckCircle2 size={18} /></span>
             ) : (
               <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>Wrong Answer <XCircle size={18} /></span>
@@ -262,10 +303,10 @@ export default function QuizComponent({ quizId, questions, onComplete, title = "
 
         <button aria-label="Action button" 
           className={styles.nextButton}
-          disabled={!selectedAnswer || showFeedback}
+          disabled={!quizState.selectedAnswer || quizState.showFeedback}
           onClick={handleQuizSubmit}
         >
-          {currentQuestion === questions.length - 1 ? "Finish Quiz" : "Submit Answer"}
+          {quizState.currentQuestion === questions.length - 1 ? "Finish Quiz" : "Submit Answer"}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Description

Fixed a race condition in the Quiz submission flow by ensuring state updates are handled correctly and do not rely on stale state values. This prevents out-of-order execution during quiz submission and ensures accurate score calculation and question progression.

Fixes #369

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## How Has This Been Tested?

* [x] Local testing
* [ ] Vercel Preview Deployment

### Tests Performed

* Verified quiz submission completes successfully.
* Confirmed score updates correctly after each answer.
* Tested multiple quiz attempts to ensure no race conditions occur.
* Verified question navigation and final score calculation.

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or errors
* [x] I have checked that the "DevPath India" branding remains intact
