### PR TITLE
fix: add offline banner for graceful network disconnection handling

### DIFF
--- a/src/components/layout/OfflineBanner.tsx
+++ b/src/components/layout/OfflineBanner.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { WifiOff } from 'lucide-react';
+import { useState, useEffect } from 'react';
+
+export default function OfflineBanner() {
+    const [isOffline, setIsOffline] = useState(false);
+
+    useEffect(() => {
+        setIsOffline(!navigator.onLine);
+
+        const handleOffline = () => setIsOffline(true);
+        const handleOnline = () => setIsOffline(false);
+
+        window.addEventListener('offline', handleOffline);
+        window.addEventListener('online', handleOnline);
+
+        return () => {
+            window.removeEventListener('offline', handleOffline);
+            window.removeEventListener('online', handleOnline);
+        };
+    }, []);
+
+    if (!isOffline) return null;
+
+    return (
+        <div className="fixed top-0 left-0 right-0 z-[2000] h-[50px] bg-gradient-to-r from-amber-600/90 to-orange-600/90 backdrop-blur-md border-b border-white/10 flex items-center justify-center px-4 shadow-lg text-white">
+            <div className="flex items-center gap-3 text-sm md:text-base font-medium text-center">
+                <WifiOff size={18} className="text-white" />
+                <span>You are offline. Some features may be unavailable.</span>
+            </div>
+        </div>
+    );
+}

--- a/src/components/layout/RouteAwareChrome.tsx
+++ b/src/components/layout/RouteAwareChrome.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 
 import MaintenanceBlocker from '@/components/layout/MaintenanceBlocker';
 import MaintenanceBanner from '@/components/layout/MaintenanceBanner';
+import OfflineBanner from '@/components/layout/OfflineBanner';
 import Navbar from '@/components/layout/Navbar';
 import FooterWrapper from '@/components/layout/FooterWrapper';
 import PageWrapper from '@/components/layout/PageWrapper';
@@ -16,6 +17,7 @@ export default function RouteAwareChrome({ children }: { children: React.ReactNo
 
     return (
         <>
+            <OfflineBanner />
             {!isAuthRoute && <MaintenanceBanner />}
             <Navbar />
 


### PR DESCRIPTION
## What

Added a global offline banner that shows when the user loses network connectivity.

## Root cause

Network disconnections caused silent failures with no user feedback.

## Changes

- Added OfflineBanner component with online/offline event listeners
- Integrated into root layout

## Verification

Tested by toggling DevTools Network tab offline mode — banner appears/disappears correctly.

Closes #441