### PR TITLE
fix: handle Firestore permission errors for roadmap progress and XP with user feedback

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -84,6 +84,11 @@ service cloud.firestore {
         allow delete: if request.auth != null && (request.auth.uid == userId || isSuperAdmin());
       }
 
+      // Progress Subcollection - Roadmap progress tracking
+      match /progress/{progressId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
       // Badges Subcollection
       // Badge grants must come from trusted backend (Cloud Functions / Admin SDK).
       // Self-writes are intentionally denied to prevent users from awarding

--- a/src/components/resources/RoadmapModal.tsx
+++ b/src/components/resources/RoadmapModal.tsx
@@ -14,12 +14,10 @@ import { jsPDF } from 'jspdf';
 import { useGamification } from '@/context/GamificationContext';
 import QuizComponent from './QuizComponent';
 
-// --- FIREBASE IMPORTS ---
 import { doc, getDoc, setDoc, serverTimestamp } from 'firebase/firestore';
-// TODO: Replace with your actual Firebase config import path
 import { db } from '@/lib/firebase'; 
-// TODO: Replace with your actual Auth hook/context
 import { useAuth } from '@/context/AuthContext'; 
+import { useNotification } from '@/context/NotificationContext';
 
 interface RoadmapModalProps {
     isOpen: boolean;
@@ -81,6 +79,7 @@ export function RoadmapModal({
     const [showQuiz, setShowQuiz] = useState(false);
 
     const { addXp } = useGamification();
+    const { showError } = useNotification();
 
     useEffect(() => {
         const mountTimeout = window.setTimeout(() => {
@@ -283,6 +282,7 @@ export function RoadmapModal({
                     }
                 } catch (error) {
                     console.error("Error fetching progress from Firestore: ", error);
+                    showError('Unable to load your roadmap progress. Please try again.', 6000);
                     if (isMounted) {
                         setCurrentPhaseIndex(0);
                         setCompletedPhases([]);
@@ -325,6 +325,7 @@ export function RoadmapModal({
                 console.log(`Progress saved: Step ${currentPhaseIndex}`);
             } catch (error) {
                 console.error("Error writing progress to Firestore: ", error);
+                showError('Unable to save your progress. Your changes may be lost.', 6000);
             }
         };
 
@@ -379,6 +380,7 @@ export function RoadmapModal({
             addXp(500, `Completed the ${roadmap.title} Pathway!`);
         } catch (err) {
             console.error('Failed to add XP or save final progress: ', err);
+            showError('Failed to save completion progress. Your XP may not be awarded.', 6000);
         }
 
         onClose();

--- a/src/context/GamificationContext.tsx
+++ b/src/context/GamificationContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useState } from 'react';
 import { Trophy, Zap, ArrowUpCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '@/context/AuthContext';
+import { useNotification } from '@/context/NotificationContext';
 
 export type NotificationType = 'xp' | 'achievement' | 'level-up';
 
@@ -122,6 +123,7 @@ const ToastMessage = ({ n, removeNotification }: { n: GamificationNotification, 
 
 export function GamificationProvider({ children }: { children: React.ReactNode }) {
     const { user, awardPoints } = useAuth();
+    const { showError } = useNotification();
     const [notifications, setNotifications] = useState<GamificationNotification[]>([]);
 
     const xp = user?.points || 0;
@@ -144,7 +146,10 @@ export function GamificationProvider({ children }: { children: React.ReactNode }
         const newLevel = Math.floor(Math.sqrt(newXp / 100));
         
         if (user && shouldPersist) {
-            awardPoints(amount).catch(err => console.error("Failed to award XP", err));
+            awardPoints(amount).catch(err => {
+                console.error("Failed to award XP", err);
+                showError('Failed to save XP. Your progress may not be persisted.', 6000);
+            });
         }
 
         const baseId = Date.now();


### PR DESCRIPTION
## Summary

Fixes Firestore permission errors that silently block roadmap progress saving/loading and XP persistence.

### Changes

1. **firestore.rules**: Added missing rule for \members/{userId}/progress/{progressId}\ subcollection - was completely denied by default, blocking all roadmap progress reads/writes.

2. **RoadmapModal.tsx**: Added user-facing toast notifications when Firestore read/write operations fail, instead of silent \console.error\.

3. **GamificationContext.tsx**: Added user-facing toast notification when XP fails to persist to Firestore.

### Testing

- Verify roadmap progress loads/saves work after rules deployment
- Verify error toast appears when Firestore operations fail (e.g. offline, permission denied)

Closes #328