### PR TITLE
fix(a11y): ensure screen reader announcements for toast notifications

### DIFF
--- a/src/components/ui/ToastContainer.tsx
+++ b/src/components/ui/ToastContainer.tsx
@@ -39,7 +39,7 @@ export function ToastContainer() {
     };
 
     return (
-        <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm pointer-events-none">
+        <div aria-live="polite" className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm pointer-events-none">
             {toasts.map(toast => {
                 const config = typeConfig[toast.type];
                 const Icon = config.icon;


### PR DESCRIPTION
## Description

Adds aria-live=polite to the ToastContainer so screen readers announce new toast notifications when they appear. This ensures users relying on assistive technology are aware of dynamic notifications.

Closes #438

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
