### PR TITLE
[Fix] Constrain event card title to 2 lines with ellipsis on mobile

### DIFF
--- a/src/components/home/Events.module.css
+++ b/src/components/home/Events.module.css
@@ -92,6 +92,13 @@
     font-weight: 600;
     margin-bottom: 0.75rem;
     line-height: 1.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    max-width: 100%;
+    word-break: break-word;
 }
 
 .meta {


### PR DESCRIPTION
## What
Constrains the event card title to a maximum of 2 lines with text-overflow ellipsis on mobile and small screens. Long event titles no longer break the card layout or overflow outside boundaries.

## Why
When an event has an exceptionally long title, it breaks the layout of the Event Card on mobile screens, causing text to overflow outside the card boundaries.

## Testing
- Applied `display: -webkit-box` with `-webkit-line-clamp: 2` to the `.eventTitle` class
- Added `overflow: hidden`, `text-overflow: ellipsis`, and `word-break: break-word` for cross-browser safety
- Existing layout and animations remain unchanged


Fixes #466