### PR TITLE
[Feature] Add scroll-to-top floating action button

### DIFF
--- a/src/components/ui/ScrollToTop.tsx
+++ b/src/components/ui/ScrollToTop.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ArrowUp } from "lucide-react";
+
+export default function ScrollToTop() {
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        const handleScroll = () => {
+            setIsVisible(window.scrollY > 300);
+        };
+
+        window.addEventListener("scroll", handleScroll, { passive: true });
+        return () => window.removeEventListener("scroll", handleScroll);
+    }, []);
+
+    const scrollToTop = () => {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+    };
+
+    return (
+        <button
+            aria-label="Scroll to top"
+            onClick={scrollToTop}
+            className={`fixed bottom-6 right-6 z-[1000] p-3 rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-300 hover:bg-primary/90 hover:scale-110 ${
+                isVisible
+                    ? "opacity-100 translate-y-0 pointer-events-auto"
+                    : "opacity-0 translate-y-4 pointer-events-none"
+            }`}
+        >
+            <ArrowUp className="w-5 h-5" />
+        </button>
+    );
+}


### PR DESCRIPTION
## What
Adds a floating `ScrollToTop` button that appears at the bottom-right of the screen when the user scrolls past 300px. Clicking it smoothly scrolls back to the top of the page.

## Why
On long pages like the Roadmaps or Wiki, scrolling back to the top manually is tedious, especially on mobile devices. This button improves navigation efficiency and user experience.

## Testing
- Appears only after scrolling down 300px
- Smooth scroll animation on click
- Fades in/out with opacity and translate-Y transitions
- Properly hidden with `pointer-events-none` when not visible
- Uses `lucide-react` ArrowUp icon consistent with the existing icon set


Fixes #464