### PR TITLE
[UI/UX] Add hover tooltips to tech stack icons on project cards

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -3,6 +3,12 @@ import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { Star, GitFork, Eye, ExternalLink, Github } from "lucide-react"
 import { PremiumCard } from "./ui/PremiumCard"
+import {
+    Tooltip,
+    TooltipTrigger,
+    TooltipContent,
+    TooltipProvider,
+} from "./ui/tooltip"
 
 interface Project {
     author: string
@@ -55,12 +61,20 @@ export function ProjectCard({ project }: { project: Project }) {
                     {/* Tech Stack */}
                     <div className="flex flex-wrap gap-2 mb-auto">
                         {project.technologies.map((tech) => (
-                            <span
-                                key={tech}
-                                className="px-3 py-1 text-xs rounded-full bg-cyan-500/10 dark:bg-cyan-500/20 border border-cyan-500/20 dark:border-cyan-500/30 text-cyan-700 dark:text-cyan-300"
-                            >
-                                {tech}
-                            </span>
+                            <TooltipProvider key={tech}>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <span
+                                            className="px-3 py-1 text-xs rounded-full bg-cyan-500/10 dark:bg-cyan-500/20 border border-cyan-500/20 dark:border-cyan-500/30 text-cyan-700 dark:text-cyan-300 cursor-default"
+                                        >
+                                            {tech}
+                                        </span>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top">
+                                        <p>{tech}</p>
+                                    </TooltipContent>
+                                </Tooltip>
+                            </TooltipProvider>
                         ))}
                     </div>
 


### PR DESCRIPTION
## What
Adds hover tooltips to each technology badge in the  component using the existing Radix UI Tooltip component.

## Why
New developers might not recognize all technology icons/badge names. Hovering over a tech stack badge now reveals the technology name in a tooltip, making the UI more inclusive and informative.

## Testing
- Uses existing  Tooltip component already in the codebase
- TooltipProvider wraps each individual badge
- Tooltip appears on hover with proper side=top positioning
- Existing layout and functionality unchanged


Fixes #463