### PR TITLE
fix: use secureFetch for admin verification request

### DIFF
--- a/src/components/auth/AdminKeyModal.tsx
+++ b/src/components/auth/AdminKeyModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Key, Lock, AlertCircle } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
+import { secureFetch } from '@/lib/apiClient';  
 
 interface AdminKeyModalProps {
     isOpen: boolean;
@@ -22,7 +23,7 @@ export default function AdminKeyModal({ isOpen, onVerified, onCancel }: AdminKey
 
         try {
             // Sending key to the secure backend route instead of checking in browser
-            const response = await fetch('/api/auth/verify-admin', {
+            const response = await secureFetch('/api/auth/verify-admin', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
Closes #427 
## Summary

Updated the admin verification flow to use the new `secureFetch` utility introduced in PR #380.

### Changes

* Imported `secureFetch` from `src/lib/apiClient`
* Replaced `fetch('/api/auth/verify-admin')` with `secureFetch('/api/auth/verify-admin')` in `src/components/auth/AdminKeyModal.tsx`

### Why

The new CSRF middleware requires mutating API requests to include the CSRF token header. Using `secureFetch` ensures the required token is automatically attached to the admin verification POST request.

### Additional Review

* Reviewed mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) within the `src` directory.
* The admin verification endpoint was the frontend `/api/*` request requiring migration to `secureFetch`.
* Other mutating requests found during review were external API calls (e.g. GitHub APIs) or utility/debug scripts and are not affected by the `/api/*` CSRF middleware.
