### PR TITLE
fix(gamification): resolve schema mismatch to use members collection …

### DIFF
--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -9,14 +9,14 @@ export function useGamification(userId: string) {
 
   useEffect(() => {
     if (!userId) return;
-    getDoc(doc(db, "users", userId)).then(snap => setProfile(snap.data()));
+    getDoc(doc(db, "members", userId)).then(snap => setProfile(snap.data()));
   }, [userId]);
 
   async function awardXP(action: keyof typeof XP_VALUES) {
     const xp = XP_VALUES[action];
-    const ref = doc(db, "users", userId);
+    const ref = doc(db, "members", userId);
     await updateDoc(ref, {
-      xp: increment(xp),
+      points: increment(xp),
       activityDates: arrayUnion(todayString()),
     });
   }


### PR DESCRIPTION
# 🚀 Fix Gamification Schema Mismatch: `users` ➔ `members` & `xp` ➔ `points` #484 
## 🎯 What does this PR do?
This pull request addresses a critical data inconsistency in the gamification system. Previously, the `useGamification` hook was incorrectly awarding experience points to a legacy `users` collection under an `xp` field. This caused new gamification events to disappear into a void, as the core application architecture tracks users in the `members` collection and uses a `points` system.

This PR re-aligns the hook with the current Firestore schema.

## 🛠️ Technical Implementation
- **Schema Alignment (Collection):** Updated the target collection reference in `awardXP` from `"users"` to `"members"` so that points are accurately credited to the authenticated user's actual profile.
- **Schema Alignment (Fields):** Replaced the outdated `xp` field with the standard `points` field in the `updateDoc` payload to ensure compatibility with the Leaderboard and Auth Context.

### 📝 Code Changes
```diff
--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -10,7 +10,7 @@ export function useGamification(userId: string) {
 
   useEffect(() => {
     if (!userId) return;
-    getDoc(doc(db, "users", userId)).then(snap => setProfile(snap.data()));
+    getDoc(doc(db, "members", userId)).then(snap => setProfile(snap.data()));
   }, [userId]);
 
   async function awardXP(action: keyof typeof XP_VALUES) {
@@ -16,6 +16,6 @@ export function useGamification(userId: string) {
-    const ref = doc(db, "users", userId);
+    const ref = doc(db, "members", userId);
     await updateDoc(ref, {
-      xp: increment(xp),
+      points: increment(xp),
       activityDates: arrayUnion(todayString()),
     });
   }
```

## 🐛 Bug Details
- **Severity:** Critical / Data Loss
- **Symptoms:** Users completing tasks (e.g., sharing resources, logging in) were not seeing their points increase on the UI or leaderboard, while Firebase was accumulating orphan documents in an unused `users` root collection.

## ✅ Verification
1. **Local Test:** Trigger an action that fires `awardXP()` (e.g., interacting with a gamified component).
2. **Firestore Check:** Verify that the `members/{uid}` document successfully receives an increment on the `points` field.
3. **UI Check:** The updated points should immediately reflect across the application via real-time listeners.
