### PR TITLE
fix: route missing profiles to branded 404

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,50 +1,5 @@
-import Link from 'next/link';
-import Button from '@/components/ui/Button';
-import { Compass, Home, Map } from 'lucide-react';
-import React from 'react';
+import NotFoundView from '@/components/layout/NotFoundView';
 
 export default function NotFound() {
-    return (
-        <div className="min-h-[70vh] py-20 flex flex-col items-center justify-center px-4 text-center relative">
-            {/* Background elements */}
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-primary/10 rounded-full blur-[120px] pointer-events-none" />
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[400px] bg-blue-500/10 rounded-full blur-[80px] pointer-events-none" />
-
-            <div className="relative z-10 flex flex-col items-center bg-card/30 backdrop-blur-xl border border-white/10 p-10 md:p-20 rounded-[3rem] shadow-2xl">
-                <div className="relative mb-8 group">
-                    <div className="absolute inset-0 bg-primary/40 blur-[50px] rounded-full group-hover:bg-primary/60 transition-all duration-700" />
-                    <div className="bg-background/50 p-6 rounded-3xl border border-white/10 shadow-inner relative z-10 backdrop-blur-sm">
-                        <Compass className="w-20 h-20 text-primary animate-[spin_8s_linear_infinite]" />
-                    </div>
-                </div>
-                
-                <h1 className="text-8xl md:text-[150px] font-black font-space mb-2 tracking-tighter text-transparent bg-clip-text bg-gradient-to-b from-white to-white/20 drop-shadow-2xl leading-none">
-                    404
-                </h1>
-                
-                <div className="h-1 w-24 bg-gradient-to-r from-transparent via-primary to-transparent mb-8 rounded-full" />
-                
-                <h2 className="text-3xl md:text-4xl font-bold mb-4 text-white font-space tracking-tight">
-                    Lost in the Void
-                </h2>
-                
-                <p className="text-muted-foreground max-w-lg mb-10 text-lg md:text-xl font-sans leading-relaxed">
-                    The page you're looking for has vanished into cyberspace. It might have been moved, deleted, or perhaps it never existed at all.
-                </p>
-                
-                <div className="flex flex-col sm:flex-row gap-4">
-                    <Link href="/" passHref>
-                        <Button aria-label="Action button"  variant="primary" icon={<Home className="w-5 h-5" />} className="w-full sm:w-auto text-lg px-8 py-6 rounded-2xl">
-                            Back to Safety
-                        </Button>
-                    </Link>
-                    <Link href="/courses" passHref>
-                        <Button aria-label="Action button"  variant="secondary" icon={<Map className="w-5 h-5" />} className="w-full sm:w-auto text-lg px-8 py-6 rounded-2xl border-white/20 hover:bg-white/5">
-                            Explore Courses
-                        </Button>
-                    </Link>
-                </div>
-            </div>
-        </div>
-    );
+    return <NotFoundView />;
 }

--- a/src/app/u/[uid]/page.tsx
+++ b/src/app/u/[uid]/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import ProfileClient from '../client';
+
+export function generateStaticParams() {
+    return [];
+}
+
+export async function generateMetadata(
+    { params }: { params: Promise<{ uid: string }> }
+): Promise<Metadata> {
+    const { uid } = await params;
+
+    return {
+        title: 'DevPath User Profile',
+        description: 'View a public DevPath community profile.',
+        alternates: {
+            canonical: `/u/${uid}`,
+        },
+        openGraph: {
+            title: 'DevPath User Profile',
+            description: 'Check out this public DevPath community profile.',
+            url: `/u/${uid}`,
+        },
+    };
+}
+
+export default async function UserProfilePage(
+    { params }: { params: Promise<{ uid: string }> }
+) {
+    const { uid } = await params;
+
+    return <ProfileClient uid={uid} />;
+}

--- a/src/app/u/client.tsx
+++ b/src/app/u/client.tsx
@@ -19,6 +19,7 @@ import { GIT_FALLBACK_STATS } from '@/lib/github';
 import { getSafeSocialUrl } from '@/lib/safe-social-url';
 import { copyToClipboard } from '@/lib/clipboard';
 import { useNotification } from '@/context/NotificationContext';
+import NotFoundView from '@/components/layout/NotFoundView';
 
 interface PublicUser {
     id?: string;
@@ -91,6 +92,7 @@ function ProfileContent({ uid }: { uid?: string }) {
     const [projects, setProjects] = useState<Project[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
+    const [showNotFound, setShowNotFound] = useState(false);
     const [activeTab, setActiveTab] = useState('Overview');
     const [copied, setCopied] = useState(false);
     const [selectedProject, setSelectedProject] = useState<Project | null>(null);
@@ -112,16 +114,19 @@ function ProfileContent({ uid }: { uid?: string }) {
 
             if (!currentUid || currentUid === 'u') {
                 setError('No user specified.');
+                setShowNotFound(false);
                 setLoading(false);
                 return;
             }
             if (currentUid.length < 3 || currentUid.length > 128 || /[<>"']/.test(currentUid)) {
                 setError('Invalid user identifier.');
+                setShowNotFound(true);
                 setLoading(false);
                 return;
             }
             setLoading(true);
             setError('');
+            setShowNotFound(false);
 
             try {
                 let userData: PublicUser | undefined;
@@ -168,6 +173,7 @@ function ProfileContent({ uid }: { uid?: string }) {
                     // Privacy Check
                     if (userData.privacySettings?.isPublic === false) {
                         setError('This profile is private.');
+                        setShowNotFound(true);
                         setLoading(false);
                         return;
                     }
@@ -289,10 +295,12 @@ function ProfileContent({ uid }: { uid?: string }) {
 
                 } else {
                     setError('User not found.');
+                    setShowNotFound(true);
                 }
             } catch (err) {
                 console.error("Error fetching user:", err);
                 setError('Failed to load profile.');
+                setShowNotFound(false);
             } finally {
                 setLoading(false);
             }
@@ -382,6 +390,10 @@ function ProfileContent({ uid }: { uid?: string }) {
     }
 
     if (error || !user) {
+        if (showNotFound) {
+            return <NotFoundView />;
+        }
+
         return (
             <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4 text-center">
                 <UserIcon size={64} className="text-muted-foreground mb-4" />
@@ -944,13 +956,7 @@ function SearchParamsFallback() {
     }
 
     if (!isValidUid(uid)) {
-        return (
-            <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4 text-center">
-                <UserIcon size={64} className="text-muted-foreground mb-4" />
-                <h1 className="text-2xl font-bold mb-2">Invalid Profile</h1>
-                <p className="text-muted-foreground">The requested profile identifier is invalid.</p>
-            </div>
-        );
+        return <NotFoundView />;
     }
 
     return <ProfileContent uid={uid} />;

--- a/src/components/layout/NotFoundView.tsx
+++ b/src/components/layout/NotFoundView.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+import Button from '@/components/ui/Button';
+import { Compass, Home, Map } from 'lucide-react';
+import React from 'react';
+
+export default function NotFoundView() {
+    return (
+        <div className="min-h-[70vh] py-20 flex flex-col items-center justify-center px-4 text-center relative">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-primary/10 rounded-full blur-[120px] pointer-events-none" />
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[400px] bg-blue-500/10 rounded-full blur-[80px] pointer-events-none" />
+
+            <div className="relative z-10 flex flex-col items-center bg-card/30 backdrop-blur-xl border border-white/10 p-10 md:p-20 rounded-[3rem] shadow-2xl">
+                <div className="relative mb-8 group">
+                    <div className="absolute inset-0 bg-primary/40 blur-[50px] rounded-full group-hover:bg-primary/60 transition-all duration-700" />
+                    <div className="bg-background/50 p-6 rounded-3xl border border-white/10 shadow-inner relative z-10 backdrop-blur-sm">
+                        <Compass className="w-20 h-20 text-primary animate-[spin_8s_linear_infinite]" />
+                    </div>
+                </div>
+
+                <h1 className="text-8xl md:text-[150px] font-black font-space mb-2 tracking-tighter text-transparent bg-clip-text bg-gradient-to-b from-white to-white/20 drop-shadow-2xl leading-none">
+                    404
+                </h1>
+
+                <div className="h-1 w-24 bg-gradient-to-r from-transparent via-primary to-transparent mb-8 rounded-full" />
+
+                <h2 className="text-3xl md:text-4xl font-bold mb-4 text-white font-space tracking-tight">
+                    Lost in the Void
+                </h2>
+
+                <p className="text-muted-foreground max-w-lg mb-10 text-lg md:text-xl font-sans leading-relaxed">
+                    The page you&apos;re looking for has vanished into cyberspace. It might have been moved, deleted, or perhaps it never existed at all.
+                </p>
+
+                <div className="flex flex-col sm:flex-row gap-4">
+                    <Link href="/" passHref>
+                        <Button aria-label="Go back to home" variant="primary" icon={<Home className="w-5 h-5" />} className="w-full sm:w-auto text-lg px-8 py-6 rounded-2xl">
+                            Back to Safety
+                        </Button>
+                    </Link>
+                    <Link href="/courses" passHref>
+                        <Button aria-label="Explore courses" variant="secondary" icon={<Map className="w-5 h-5" />} className="w-full sm:w-auto text-lg px-8 py-6 rounded-2xl border-white/20 hover:bg-white/5">
+                            Explore Courses
+                        </Button>
+                    </Link>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Fixes #465

## Summary
- add an App Router `/u/[uid]` profile route so shared profile links are handled directly
- extract the existing 404 UI into a reusable `NotFoundView` component
- render the branded 404 for invalid profile identifiers, private profiles, and valid-looking profile IDs that cannot be found

## When the 404 appears
- unmatched app routes still use `src/app/not-found.tsx`
- `/u/<uid>` with unsafe or malformed identifiers now shows the branded 404 instead of the small invalid-profile fallback
- `/u/<uid>` where no matching member/admin profile is found shows the branded 404
- `/u/<uid>` for a profile explicitly marked private shows the branded 404
- `/u` without a user id keeps the existing “No user specified” prompt, because that is an incomplete URL rather than a missing profile

## Validation
- `git diff --check`
- `npx eslint src/app/not-found.tsx src/components/layout/NotFoundView.tsx src/app/u/[uid]/page.tsx`
- `npm run build` was attempted, but the current branch is blocked by unrelated existing failures in `src/app/notifications/page.tsx`, missing `@tanstack/react-virtual`, and missing `fuse.js`
- local dev server verified `http://127.0.0.1:3011/u/%3Cbad%3E` renders the shared 404; screenshot captured locally at `/tmp/devpath-profile-404-465.png`