### PR TITLE
fix(components): resolve react state memory leaks on unmount via mana…

### DIFF
--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -1,6 +1,6 @@
 "use client";
 const AVATAR_FALLBACK = process.env.NEXT_PUBLIC_AVATAR_FALLBACK_URL ?? 'https://ui-avatars.com/api';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/navigation';
@@ -41,6 +41,13 @@ export default function UserProfile() {
     const { user, logout, updateUserProfile, awardPoints } = useAuth();
     const { showSuccess, showError } = useNotification();
     const router = useRouter();
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        };
+    }, []);
 
     useEffect(() => {
         if (user?.email === 'devpathind.community@gmail.com') {
@@ -204,7 +211,8 @@ useEffect(() => {
 
         if (copied) {
             setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => setCopied(false), 2000);
             showSuccess('Profile link copied to clipboard.');
         } else {
             showError('Copying the profile link is not supported in this browser.');

--- a/src/components/source-code/InteractiveSteps.tsx
+++ b/src/components/source-code/InteractiveSteps.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { GitFork, Download, Terminal, Play, CheckCircle, Copy, FileText } from 'lucide-react';
 import { copyToClipboard } from '@/lib/clipboard';
@@ -52,6 +52,7 @@ const steps = [
 export default function InteractiveSteps() {
     const [activeStep, setActiveStep] = useState(0);
     const [copied, setCopied] = useState(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         const interval = setInterval(() => {
@@ -60,12 +61,19 @@ export default function InteractiveSteps() {
         return () => clearInterval(interval);
     }, []);
 
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        };
+    }, []);
+
     const handleCopy = async (text: string) => {
         const copiedSuccessfully = await copyToClipboard(text);
 
         if (copiedSuccessfully) {
             setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => setCopied(false), 2000);
         }
     };
 


### PR DESCRIPTION
# 🚀 Fix React Memory Leaks via Unmanaged Timeouts #487 

## 🎯 What does this PR do?
This pull request addresses a common React performance issue where state updates are triggered on unmounted components, causing memory leaks and console warnings.

In `InteractiveSteps.tsx` and `UserProfile.tsx`, success states (like "Copied to clipboard") were cleared using unmanaged `setTimeout` calls:
```typescript
setCopied(true);
setTimeout(() => setCopied(false), 2000); 
```

If a user navigated away from the page before the 2-second timer completed, the component would unmount, but the timeout would still execute and attempt to call `setCopied(false)`, throwing the infamous *"Can't perform a React state update on an unmounted component"* warning.

## 🛠️ Technical Implementation
- Imported `useRef` into `InteractiveSteps.tsx` and `UserProfile.tsx`.
- Assigned the timer ID to `timeoutRef.current` when the copy action is triggered.
- Created a `useEffect` hook with a cleanup function that strictly calls `clearTimeout(timeoutRef.current)` when the component unmounts.

### 📝 Code Changes
```diff
--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 // ...
 
 export default function UserProfile() {
     // ...
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        };
+    }, []);
 
     const handleShareProfile = async () => {
         // ...
         if (copied) {
             setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => setCopied(false), 2000);
             showSuccess('Profile link copied to clipboard.');
         }
```
*(Identical logic applied to `InteractiveSteps.tsx`)*

## 🐛 Bug Details
- **Severity:** Beginner / Performance
- **Symptoms:** Subtle memory leaks degrading SPA performance over time and cluttering the console with React warnings during rapid navigation.

## ✅ Verification
1. Open the Developer Tools Console.
2. Navigate to a component that uses the copy functionality (like the User Profile Share button).
3. Click "Copy" and immediately click a link to navigate away to another page.
4. Verify that the "Can't perform a React state update on an unmounted component" warning no longer appears in the console.
