### PR TITLE
 Fix CI/CD Pipeline: Enable Next.js Static Export

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'export',
   devIndicators: {
     // @ts-ignore - buildActivity is valid but missing in type definition
     buildActivity: false,


### PR DESCRIPTION
# 🚀 Fix CI/CD Pipeline: Enable Next.js Static Export #500 
 
## 🎯 What does this PR do?
This pull request resolves a critical CI/CD pipeline failure where the GitHub Actions workflow (`nextjs.yml`) would crash during the "Upload artifact" step. 

The workflow expects the Next.js build process to generate a static HTML output folder named `./out`. However, by default, Next.js generates a Node.js server build in the `.next/` directory. By adding the `output: 'export'` configuration directive, we instruct the Next.js compiler to perform a full static export, ensuring that the `./out` directory is populated with static assets ready for GitHub Pages hosting.

## 🛠️ Technical Implementation
- Added the `output: 'export'` parameter to the root configuration object inside `next.config.ts`.

### 📝 Code Changes
```diff
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@
 
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'export',
   devIndicators: {
     // @ts-ignore - buildActivity is valid but missing in type definition
     buildActivity: false,
```

## 🐛 Bug Details
- **Severity:** High / Deployment Blocker
- **Symptoms:** The `.github/workflows/nextjs.yml` GitHub action fails with the error message: `Directory './out' does not exist`. 

## ✅ Verification
1. Trigger a deployment by merging this PR into `master` or running it manually from the Actions tab.
2. Observe the "Build with Next.js" step in the CI logs; it should now say "Exporting (..)" and successfully generate the static assets.
3. Observe the "Upload artifact" step; it should now successfully locate and archive the `./out` directory.

