### PR TITLE
fix: Add line-clamp to prevent text overflow in event card titles on mobile

### DIFF
--- a/src/components/home/Events.module.css
+++ b/src/components/home/Events.module.css
@@ -86,12 +86,16 @@
     margin-bottom: 0.75rem;
     font-weight: 500;
 }
-
 .eventTitle {
     font-size: 1.25rem;
     font-weight: 600;
     margin-bottom: 0.75rem;
     line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
 }
 
 .meta {


### PR DESCRIPTION
## Problem
Long event titles in the Event Card were overflowing outside card boundaries on mobile (sm) breakpoints, breaking the layout.

## Fix
Added CSS overflow constraints to the .eventTitle class in Events.module.css:
- line-clamp: 2 - caps title to 2 lines with ellipsis
- overflow: hidden - prevents horizontal overflow
- word-break: break-word - handles edge cases with long unbroken strings

## Files Changed
src/components/home/Events.module.css

## Related Issue
Closes #466 