### PR TITLE
Added hover tooltips to tech stack icons on Project Cards in the Community Showcase.

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,5 +1,4 @@
 "use client"
-
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { Star, GitFork, Eye, ExternalLink, Github } from "lucide-react"
@@ -62,23 +61,22 @@ export function ProjectCard({ project }: { project: Project }) {
                     {/* Tech Stack */}
                      <div className="flex flex-wrap gap-2 mb-auto">
                         {project.technologies.map((tech) => (
-
                     <TooltipProvider key={tech}>
-    <Tooltip>
-        <TooltipTrigger asChild>
-            <span
-                className="px-3 py-1 text-xs rounded-full bg-cyan-500/10 dark:bg-cyan-500/20 border border-cyan-500/20 dark:border-cyan-500/30 text-cyan-700 dark:text-cyan-300 cursor-default"
-            >
-                {tech}
-            </span>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-            <p>{tech}</p>
-        </TooltipContent>
-    </Tooltip>
-</TooltipProvider>
-        ))}
-    </div>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                  <span
+                   className="px-3 py-1 text-xs rounded-full bg-cyan-500/10 dark:bg-cyan-500/20 border border-cyan-500/20 dark:border-cyan-500/30 text-cyan-700 dark:text-cyan-300 cursor-default"
+                   >
+                  {tech}
+                   </span>
+                     </TooltipTrigger>
+                       <TooltipContent side="top">
+                         <p>{tech}</p>
+                      </TooltipContent>
+                        </Tooltip>
+                       </TooltipProvider>
+                     ))}
+                  </div>
 
                     {/* Stats */}
                     <div className="flex items-center gap-6 text-sm text-gray-500 dark:text-gray-400 mt-4 pt-4 border-t border-black/5 dark:border-white/10">

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -14,7 +14,6 @@ import {
 interface Project {
     author: string
     title: string
-    skills?: string[]; 
     technologies: string[]
     stats: {
         stars: number
@@ -61,29 +60,25 @@ export function ProjectCard({ project }: { project: Project }) {
                     </h3>
 
                     {/* Tech Stack */}
-{project.skills && project.skills.length > 0 && (
-    <div className="flex flex-wrap gap-1.5 mb-4">
-        {project.skills.slice(0, 3).map(skill => (
-            <TooltipProvider key={skill}>
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <span className="px-2 py-0.5 bg-secondary/50 text-secondary-foreground text-[10px] rounded-full border border-border/50 cursor-default">
-                            {skill}
-                        </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">
-                        <p>{skill}</p>
-                    </TooltipContent>
-                </Tooltip>
-            </TooltipProvider>
-        ))}
-        {project.skills.length > 3 && (
-            <span className="px-2 py-0.5 bg-secondary/50 text-secondary-foreground text-[10px] rounded-full border border-border/50">
-                +{project.skills.length - 3}
+                     <div className="flex flex-wrap gap-2 mb-auto">
+                        {project.technologies.map((tech) => (
+
+                    <TooltipProvider key={tech}>
+    <Tooltip>
+        <TooltipTrigger asChild>
+            <span
+                className="px-3 py-1 text-xs rounded-full bg-cyan-500/10 dark:bg-cyan-500/20 border border-cyan-500/20 dark:border-cyan-500/30 text-cyan-700 dark:text-cyan-300 cursor-default"
+            >
+                {tech}
             </span>
-        )}
+        </TooltipTrigger>
+        <TooltipContent side="top">
+            <p>{tech}</p>
+        </TooltipContent>
+    </Tooltip>
+</TooltipProvider>
+        ))}
     </div>
-)}
 
                     {/* Stats */}
                     <div className="flex items-center gap-6 text-sm text-gray-500 dark:text-gray-400 mt-4 pt-4 border-t border-black/5 dark:border-white/10">

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,12 +1,20 @@
 "use client"
+
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { Star, GitFork, Eye, ExternalLink, Github } from "lucide-react"
 import { PremiumCard } from "./ui/PremiumCard"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "./ui/tooltip";
 
 interface Project {
     author: string
     title: string
+    skills?: string[]; 
     technologies: string[]
     stats: {
         stars: number
@@ -53,16 +61,29 @@ export function ProjectCard({ project }: { project: Project }) {
                     </h3>
 
                     {/* Tech Stack */}
-                    <div className="flex flex-wrap gap-2 mb-auto">
-                        {project.technologies.map((tech) => (
-                            <span
-                                key={tech}
-                                className="px-3 py-1 text-xs rounded-full bg-cyan-500/10 dark:bg-cyan-500/20 border border-cyan-500/20 dark:border-cyan-500/30 text-cyan-700 dark:text-cyan-300"
-                            >
-                                {tech}
-                            </span>
-                        ))}
-                    </div>
+{project.skills && project.skills.length > 0 && (
+    <div className="flex flex-wrap gap-1.5 mb-4">
+        {project.skills.slice(0, 3).map(skill => (
+            <TooltipProvider key={skill}>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span className="px-2 py-0.5 bg-secondary/50 text-secondary-foreground text-[10px] rounded-full border border-border/50 cursor-default">
+                            {skill}
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                        <p>{skill}</p>
+                    </TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
+        ))}
+        {project.skills.length > 3 && (
+            <span className="px-2 py-0.5 bg-secondary/50 text-secondary-foreground text-[10px] rounded-full border border-border/50">
+                +{project.skills.length - 3}
+            </span>
+        )}
+    </div>
+)}
 
                     {/* Stats */}
                     <div className="flex items-center gap-6 text-sm text-gray-500 dark:text-gray-400 mt-4 pt-4 border-t border-black/5 dark:border-white/10">


### PR DESCRIPTION
## Problem
Tech stack tags in the ProjectCard component had no labels on hover, making it difficult for newer developers to identify technologies at a glance.

## Solution
Wrapped each technology tag in the ProjectCard component with Radix UI Tooltip components (TooltipProvider, Tooltip, TooltipTrigger, TooltipContent) already available in the codebase via ./ui/tooltip.
- Hovering over any tech tag now shows the technology name as a tooltip
- side="top" ensures tooltip appears above the tag
- cursor-default added for better UX
- Zero new dependencies - used existing Radix UI tooltip component

## Files Changed
- src/components/ProjectCard.tsx

## Related Issue
Closes #463 
