### PR TITLE
feat(seo): add dynamic OpenGraph meta tags for user profiles

### DIFF
--- a/src/app/u/[uid]/page.tsx
+++ b/src/app/u/[uid]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import ProfileClient from '../client';
+import { db } from '@/lib/firebase';
+import { doc, getDoc, collection, query, where, getDocs } from 'firebase/firestore';
 
 export function generateStaticParams() {
     return [];
@@ -10,16 +12,73 @@ export async function generateMetadata(
 ): Promise<Metadata> {
     const { uid } = await params;
 
+    let title = 'DevPath User Profile';
+    let description = 'View a public DevPath community profile.';
+    let imageUrl = '/DevPath-logo.webp';
+
+    if (db) {
+        try {
+            let userDoc = await getDoc(doc(db, 'members', uid));
+
+            if (!userDoc.exists()) {
+                const q = query(collection(db, 'members'), where('uid', '==', uid));
+                const querySnapshot = await getDocs(q);
+                if (!querySnapshot.empty) {
+                    userDoc = querySnapshot.docs[0];
+                }
+            }
+
+            if (!userDoc.exists()) {
+                userDoc = await getDoc(doc(db, 'admins', uid));
+                if (!userDoc.exists()) {
+                    const q = query(collection(db, 'admins'), where('uid', '==', uid));
+                    const querySnapshot = await getDocs(q);
+                    if (!querySnapshot.empty) {
+                        userDoc = querySnapshot.docs[0];
+                    }
+                }
+            }
+
+            if (userDoc.exists()) {
+                const data = userDoc.data();
+                if (data?.privacySettings?.isPublic !== false) {
+                    title = data.name ? `${data.name} | DevPath Profile` : title;
+                    description = data.bio || `Check out ${data.name || 'this user'}'s profile on DevPath.`;
+                    if (data.photoURL) {
+                        imageUrl = data.photoURL;
+                    }
+                }
+            }
+        } catch (error) {
+            console.error("Error fetching user metadata:", error);
+        }
+    }
+
     return {
-        title: 'DevPath User Profile',
-        description: 'View a public DevPath community profile.',
+        title,
+        description,
         alternates: {
             canonical: `/u/${uid}`,
         },
         openGraph: {
-            title: 'DevPath User Profile',
-            description: 'Check out this public DevPath community profile.',
+            title,
+            description,
             url: `/u/${uid}`,
+            images: [
+                {
+                    url: imageUrl,
+                    width: 800,
+                    height: 600,
+                    alt: title,
+                }
+            ],
+            type: 'profile',
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title,
+            description,
+            images: [imageUrl],
         },
     };
 }


### PR DESCRIPTION
## Summary
This PR introduces server‑side generation of SEO‑friendly metadata for the dynamic user‑profile route (/u/[uid]). When a profile is shared on Twitter, Discord, or any other platform, the preview now displays the user’s name, bio, and avatar instead of the generic DevPath card.

## Fix
- Improved social sharing – richer preview cards boost click‑throughs and community visibility.
- SEO compliance – each profile now contains a unique <title>, <meta description> and OpenGraph/Twitter tags.
- User experience – members can proudly share their personalized profiles with accurate information.

Closes #436 