### PR TITLE
feat: enhance DevCard with social links, logo, and download fix

### DIFF
--- a/src/components/profile/DevCard.module.css
+++ b/src/components/profile/DevCard.module.css
@@ -359,6 +359,24 @@
   white-space: nowrap;
 }
 
+.metaRowLink {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--devcard-text-soft);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.metaRowLink:hover {
+  color: #00d4ff;
+}
+
 /* ── Level progress ────────────────────────────────────────────────── */
 .progressSection {
   width: 100%;
@@ -428,8 +446,9 @@
 }
 
 .statCard:hover {
-  border-color: rgba(0, 212, 255, 0.18);
-  transform: translateY(-1px);
+  border-color: rgba(0, 212, 255, 0.28);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(0, 212, 255, 0.10);
 }
 
 .statIconWrap {
@@ -612,11 +631,20 @@
 }
 
 .footerBrand {
+  display: flex;
+  align-items: center;
+  gap: 7px;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.05em;
   color: rgba(0, 212, 255, 0.75);
   text-transform: uppercase;
+}
+
+.footerLogo {
+  border-radius: 4px;
+  opacity: 0.85;
+  object-fit: contain;
 }
 
 .footerUrl {

--- a/src/components/profile/DevCard.tsx
+++ b/src/components/profile/DevCard.tsx
@@ -7,7 +7,7 @@ import {
   Download, Link2, Check, MapPin, Calendar,
   Trophy, Zap, Flame, Star, Award, Github,
   Layers, Code2, Globe, Users, Brain,
-  ChevronRight, Sparkles, Medal,
+  ChevronRight, Sparkles, Medal, Linkedin, Instagram,
 } from 'lucide-react';
 import { calculateLevel } from '@/lib/points';
 import { copyToClipboard } from '@/lib/clipboard';
@@ -209,11 +209,28 @@ export default function DevCard({ user }: { user: any }) {
   };
 
   const handleDownload = async () => {
-    // Download functionality temporarily disabled in build environment.
-    // Restoring this requires bundler-compatible html2canvas integration.
-    // For now, show a friendly message to the user.
-    if (typeof window !== 'undefined') {
-      alert('DevCard download is temporarily disabled.');
+    if (!cardRef.current) return;
+    setDownloading(true);
+    try {
+      await waitForCardImages(cardRef.current);
+      const html2canvas = (await import('html2canvas')).default;
+      const canvas = await html2canvas(cardRef.current, {
+        useCORS: true,
+        allowTaint: false,
+        backgroundColor: null,
+        scale: 2,
+        logging: false,
+      });
+      const url = canvas.toDataURL('image/png');
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `devcard-${user?.name?.replace(/\s+/g, '-').toLowerCase() ?? 'devcard'}.png`;
+      a.click();
+      showSuccess('DevCard downloaded successfully.');
+    } catch {
+      showError('Failed to download DevCard. Please try again.');
+    } finally {
+      setDownloading(false);
     }
   };
 
@@ -325,6 +342,16 @@ export default function DevCard({ user }: { user: any }) {
               )}
               <span className={styles.metaRow}><Calendar size={10} />Joined {fmtDate(user?.createdAt)}</span>
               {user?.githubStats?.username && <span className={styles.metaRow}><Github size={10} />{user.githubStats.username}</span>}
+              {user?.linkedin && (
+                <a href={user.linkedin} target="_blank" rel="noopener noreferrer" className={styles.metaRowLink}>
+                  <Linkedin size={10} />LinkedIn
+                </a>
+              )}
+              {user?.instagram && (
+                <a href={user.instagram} target="_blank" rel="noopener noreferrer" className={styles.metaRowLink}>
+                  <Instagram size={10} />Instagram
+                </a>
+              )}
             </motion.div>
             <motion.div className={styles.progressSection} variants={item}>
               <div className={styles.progressMeta}><span className={styles.progressLabel}>Level Progress</span><span className={styles.progressPct}>{Math.round(levelInfo.progress)}%</span></div>
@@ -375,7 +402,17 @@ export default function DevCard({ user }: { user: any }) {
           </motion.div>
 
           <div className={styles.footer}>
-            <span className={styles.footerBrand}>DevPath · Developer Network</span>
+            <span className={styles.footerBrand}>
+              <Image
+                src="/DevPath-logo.webp"
+                alt="DevPath"
+                width={18}
+                height={18}
+                className={styles.footerLogo}
+                unoptimized
+              />
+              DevPath · Developer Network
+            </span>
             <span className={styles.footerUrl}><ChevronRight size={11} style={{ opacity: 0.5 }} />devpath.in</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Enhances the existing `DevCard` component with all four improvements requested in the issue 

1. **Social Links** — LinkedIn and Instagram links now appear in the left panel meta
   section alongside the existing GitHub username row. Links open in a new tab and only
   render if the user has set those fields on their profile.

2. **DevPath Community Logo** — The footer brand area now renders the actual
   `/DevPath-logo.webp` asset (via `next/image`) alongside the brand text, replacing
   the plain-text-only footer.

3. **Download Fixed** — The download button was previously disabled with a placeholder
   `alert()`. It now works correctly using a dynamic import of `html2canvas` (already
   in `package.json`), waits for all card images to finish loading via the existing
   `waitForCardImages` helper, and exports a 2× resolution PNG named
   `devcard-{username}.png`. Success and error states are surfaced via the existing
   `showSuccess` / `showError` notification hooks.

4. **UI Polish** — Stat card hover now lifts `2px` (up from `1px`) and adds a subtle
   cyan `box-shadow` glow, giving the card a more polished interactive feel.

---

## Motivation

The DevCard is the primary shareable artifact on DevPath. The broken download made it
unusable as a share tool. Missing social links meant users couldn't showcase their
LinkedIn/Instagram from the card. The plain-text footer lacked brand identity.
This PR brings the card in line with the expected feature set.

---

## Screenshot 
<img width="1600" height="910" alt="Screenshot (757)" src="https://github.com/user-attachments/assets/a437739c-4661-49b4-a21d-6bd39deba38c" />

Key changes visible:

🔗 LinkedIn & Instagram links in left panel
🖼️ DevPath logo in footer
⬇️ Download Card button functional
✨ Stat card hover glow

## Testing Checklist

- [x] Social links appear in left panel when `user.linkedin` / `user.instagram` are set
- [x] Social links are hidden when fields are empty or unset
- [x] Social links open in a new tab (`target="_blank"`)
- [x] LinkedIn link hover turns cyan (`#00d4ff`)
- [x] DevPath logo renders correctly in footer (light and dark mode)
- [x] Download button exports a `devcard-{name}.png` at 2× resolution
- [x] Downloaded PNG contains only the card (no surrounding page chrome)
- [x] Download error state shows notification if `html2canvas` fails
- [x] `html2canvas` does not appear in the initial server-rendered bundle (lazy import)
- [x] Stat card hover lifts 2px with cyan glow
- [x] No TypeScript errors or console warnings
- [x] Card stacks to single column on mobile (below 600px)
- [x] Dark mode styles unchanged and correct

---

Closes #530 