### PR TITLE
fix: resolve navbar overlap with NextBestActionWidget

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,16 +6,18 @@ import dynamic from 'next/dynamic';
 import BackToTop from '@/components/BackToTop';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import NextBestActionWidget from '@/components/NextBestActionWidget';
+
 const Sponsors = dynamic(() => import('@/components/home/Sponsors'));
 const Mission = dynamic(() => import('@/components/home/Mission'));
 const CodingNews = dynamic(() => import('@/components/home/CodingNews'));
 const PastCollaborations = dynamic(() => import('@/components/home/PastCollaborations'));
+
 export default function Home() {
   return (
     <>
       <main className="min-h-screen bg-background">
         <FloatingParticles />
-        <div className="max-w-6xl mx-auto px-4 pt-8">
+        <div className="max-w-6xl mx-auto px-4 pt-28">
           <NextBestActionWidget />
         </div>
         <Hero />


### PR DESCRIPTION

Closes #528

### Root Cause
The `NextBestActionWidget` wrapper in `src/app/page.tsx` had `pt-8` (32px) of top padding, which was not enough to clear the fixed navbar positioned at ~84px from the top of the viewport. This caused the widget to visually overlap with the navbar on both `/` and `/terms-and-conditions`.

### Fix
Updated the wrapper padding from `pt-8` to `pt-28` (112px) to ensure the widget always renders below the fixed navbar.

### Changes
- `src/app/page.tsx` — changed `pt-8` to `pt-28` on the widget wrapper div
> Note: The `/terms` page was also checked and is unaffected — content already renders correctly below the navbar with no overlap.

### Before & After
## Before 
<img width="1000" height="500" alt="Screenshot (729)" src="https://github.com/user-attachments/assets/0a518bd6-cfcd-45e4-8f58-5edb931dfa82" />

## After 
<img width="1000" height="500" alt="Screenshot (728)" src="https://github.com/user-attachments/assets/ac586941-6788-45bc-87aa-4ca098bb82b2" />

### Testing
- ✅ Tested on `/` (home page)
- ✅ Tested on `/terms` — no overlap, no changes needed
- ✅ No other pages or components affected

