### PR TITLE
fix: resolve dynamic profile route 404 error under static exports

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
 import NotFoundView from '@/components/layout/NotFoundView';
 
 export default function NotFound() {
-    return <NotFoundView />;
+  const pathname = usePathname();
+  const router = useRouter();
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  useEffect(() => {
+    if (pathname?.startsWith('/u/')) {
+      const parts = pathname.slice(3).split('/');
+      const uid = parts[0]?.split('?')[0];
+      if (uid && uid !== 'dummy' && uid !== '') {
+        setIsRedirecting(true);
+        router.replace(`/u?uid=${uid}`);
+      }
+    }
+  }, [pathname, router]);
+
+  if (isRedirecting) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  return <NotFoundView />;
 }

--- a/src/app/u/[uid]/page.tsx
+++ b/src/app/u/[uid]/page.tsx
@@ -1,94 +1,107 @@
 import type { Metadata } from 'next';
 import ProfileClient from '../client';
 import { db } from '@/lib/firebase';
-import { doc, getDoc, collection, query, where, getDocs } from 'firebase/firestore';
+import {
+  doc,
+  getDoc,
+  collection,
+  query,
+  where,
+  getDocs,
+} from 'firebase/firestore';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
-    return [{ uid: 'dummy' }];
+  return [{ uid: 'dummy' }];
 }
 
-export async function generateMetadata(
-    { params }: { params: Promise<{ uid: string }> }
-): Promise<Metadata> {
-    const { uid } = await params;
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ uid: string }>;
+}): Promise<Metadata> {
+  const { uid } = await params;
 
-    let title = 'DevPath User Profile';
-    let description = 'View a public DevPath community profile.';
-    let imageUrl = '/DevPath-logo.webp';
+  let title = 'DevPath User Profile';
+  let description = 'View a public DevPath community profile.';
+  let imageUrl = '/DevPath-logo.webp';
 
-    if (db) {
-        try {
-            let userDoc = await getDoc(doc(db, 'members', uid));
+  if (db) {
+    try {
+      let userDoc = await getDoc(doc(db, 'members', uid));
 
-            if (!userDoc.exists()) {
-                const q = query(collection(db, 'members'), where('uid', '==', uid));
-                const querySnapshot = await getDocs(q);
-                if (!querySnapshot.empty) {
-                    userDoc = querySnapshot.docs[0];
-                }
-            }
-
-            if (!userDoc.exists()) {
-                userDoc = await getDoc(doc(db, 'admins', uid));
-                if (!userDoc.exists()) {
-                    const q = query(collection(db, 'admins'), where('uid', '==', uid));
-                    const querySnapshot = await getDocs(q);
-                    if (!querySnapshot.empty) {
-                        userDoc = querySnapshot.docs[0];
-                    }
-                }
-            }
-
-            if (userDoc.exists()) {
-                const data = userDoc.data();
-                if (data?.privacySettings?.isPublic !== false) {
-                    title = data.name ? `${data.name} | DevPath Profile` : title;
-                    description = data.bio || `Check out ${data.name || 'this user'}'s profile on DevPath.`;
-                    if (data.photoURL) {
-                        imageUrl = data.photoURL;
-                    }
-                }
-            }
-        } catch (error) {
-            console.error("Error fetching user metadata:", error);
+      if (!userDoc.exists()) {
+        const q = query(collection(db, 'members'), where('uid', '==', uid));
+        const querySnapshot = await getDocs(q);
+        if (!querySnapshot.empty) {
+          userDoc = querySnapshot.docs[0];
         }
-    }
+      }
 
-    return {
-        title,
-        description,
-        alternates: {
-            canonical: `/u/${uid}`,
+      if (!userDoc.exists()) {
+        userDoc = await getDoc(doc(db, 'admins', uid));
+        if (!userDoc.exists()) {
+          const q = query(collection(db, 'admins'), where('uid', '==', uid));
+          const querySnapshot = await getDocs(q);
+          if (!querySnapshot.empty) {
+            userDoc = querySnapshot.docs[0];
+          }
+        }
+      }
+
+      if (userDoc.exists()) {
+        const data = userDoc.data();
+        if (data?.privacySettings?.isPublic !== false) {
+          title = data.name ? `${data.name} | DevPath Profile` : title;
+          description =
+            data.bio ||
+            `Check out ${data.name || 'this user'}'s profile on DevPath.`;
+          if (data.photoURL) {
+            imageUrl = data.photoURL;
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching user metadata:', error);
+    }
+  }
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/u/${uid}`,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `/u/${uid}`,
+      images: [
+        {
+          url: imageUrl,
+          width: 800,
+          height: 600,
+          alt: title,
         },
-        openGraph: {
-            title,
-            description,
-            url: `/u/${uid}`,
-            images: [
-                {
-                    url: imageUrl,
-                    width: 800,
-                    height: 600,
-                    alt: title,
-                }
-            ],
-            type: 'profile',
-        },
-        twitter: {
-            card: 'summary_large_image',
-            title,
-            description,
-            images: [imageUrl],
-        },
-    };
+      ],
+      type: 'profile',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [imageUrl],
+    },
+  };
 }
 
-export default async function UserProfilePage(
-    { params }: { params: Promise<{ uid: string }> }
-) {
-    const { uid } = await params;
+export default async function UserProfilePage({
+  params,
+}: {
+  params: Promise<{ uid: string }>;
+}) {
+  const { uid } = await params;
 
-    return <ProfileClient uid={uid} />;
+  return <ProfileClient uid={uid} />;
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import Image from "next/image";
+import Link from 'next/link';
+import Image from 'next/image';
 import {
   Github,
   Book,
@@ -8,12 +8,13 @@ import {
   RefreshCw,
   Code,
   MessageSquare,
-} from "lucide-react";
-import logo from "@/assets/logo.webp";
-import styles from "./Footer.module.css";
-import { MagneticText } from "../ui/magnetic-text";
-import { siteConfig } from "@/config/siteConfig";
-import AppStoreButtons from "../ui/AppStoreButtons";
+  Shield,
+} from 'lucide-react';
+import logo from '@/assets/logo.webp';
+import styles from './Footer.module.css';
+import { MagneticText } from '../ui/magnetic-text';
+import { siteConfig } from '@/config/siteConfig';
+import AppStoreButtons from '../ui/AppStoreButtons';
 
 export default function Footer() {
   return (
@@ -29,7 +30,7 @@ export default function Footer() {
                 width={34}
                 height={34}
                 className="rounded-full"
-                style={{ marginRight: "12px" }}
+                style={{ marginRight: '12px' }}
               />
               <p className="font-bold text-3xl text-gray-900 dark:text-white">
                 {siteConfig.name}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,7 @@
-import { initializeApp, getApps, getApp, FirebaseApp } from "firebase/app";
-import { getAnalytics, isSupported } from "firebase/analytics";
-import { getFirestore, Firestore } from "firebase/firestore";
-import { getAuth, Auth } from "firebase/auth";
+import { initializeApp, getApps, getApp, FirebaseApp } from 'firebase/app';
+import { getAnalytics, isSupported } from 'firebase/analytics';
+import { getFirestore, Firestore } from 'firebase/firestore';
+import { getAuth, Auth } from 'firebase/auth';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -20,15 +20,21 @@ if (isProduction) {
     .map(([key]) => key);
 
   if (missingKeys.length > 0) {
-    throw new Error(`Production Deployment Error: Missing required Firebase environment variables: ${missingKeys.join(', ')}`);
+    throw new Error(
+      `Production Deployment Error: Missing required Firebase environment variables: ${missingKeys.join(', ')}`
+    );
   }
 } else {
   // Safe Mock Fallbacks strictly for local development/testing only
-  firebaseConfig.apiKey = firebaseConfig.apiKey || "mock-api-key-for-local-testing-only-123456";
-  firebaseConfig.authDomain = firebaseConfig.authDomain || "mock-app.firebaseapp.com";
-  firebaseConfig.projectId = firebaseConfig.projectId || "mock-app-id";
-  firebaseConfig.storageBucket = firebaseConfig.storageBucket || "mock-app.appspot.com";
-  firebaseConfig.messagingSenderId = firebaseConfig.messagingSenderId || "1234567890";
+  firebaseConfig.apiKey =
+    firebaseConfig.apiKey || 'mock-api-key-for-local-testing-only-123456';
+  firebaseConfig.authDomain =
+    firebaseConfig.authDomain || 'mock-app.firebaseapp.com';
+  firebaseConfig.projectId = firebaseConfig.projectId || 'mock-app-id';
+  firebaseConfig.storageBucket =
+    firebaseConfig.storageBucket || 'mock-app.appspot.com';
+  firebaseConfig.messagingSenderId =
+    firebaseConfig.messagingSenderId || '1234567890';
 }
 
 const isFirebaseConfigValid = Boolean(
@@ -46,14 +52,20 @@ const app: FirebaseApp | null = isFirebaseConfigValid
   : null;
 
 if (!app) {
-  console.warn('Firebase is not configured. Running in local UI-only mode without Firebase auth or Firestore.');
+  console.warn(
+    'Firebase is not configured. Running in local UI-only mode without Firebase auth or Firestore.'
+  );
 }
 
 // For build-time typing we export `db` as a Firestore instance. At runtime
 // `app` may be null when Firebase isn't configured; in that case we provide
 // a minimal cast to satisfy TypeScript while keeping runtime behavior safe.
-const db: Firestore = app ? getFirestore(app) as Firestore : (null as unknown as Firestore);
-const auth: Auth = app ? getAuth(app) as Auth : ({} as Auth);
-const firebaseAvailable = Boolean(app);
+const db: Firestore = app
+  ? (getFirestore(app) as Firestore)
+  : (null as unknown as Firestore);
+const auth: Auth = app ? (getAuth(app) as Auth) : ({} as Auth);
+const firebaseAvailable =
+  Boolean(app) &&
+  firebaseConfig.apiKey !== 'mock-api-key-for-local-testing-only-123456';
 
 export { db, auth, firebaseAvailable, firebaseConfig };


### PR DESCRIPTION
## Summary

This PR resolves the `404 Not Found` error when visiting or sharing dynamic profile links in the format `/u/[uid]`. 

## Changes Made

- **Client-Side Routing Fallback** (`src/app/not-found.tsx`): Configured Next.js's global `NotFound` page to detect dynamic profile paths (`/u/[uid]`). It redirects them client-side to `/u?uid=[uid]`, allowing dynamic profile components (`ProfileClient`) to fetch and display the user's data on static hosting platforms.
- **Footer Icon Fix** (`src/components/layout/Footer.tsx`): Imported the missing `Shield` icon from `lucide-react` to resolve a TypeScript type check error that was breaking production builds.
- **Firebase Local Mode Guard** (`src/lib/firebase.ts`): Configured `firebaseAvailable` to evaluate to `false` when mock testing API keys are used, preventing the browser application from freezing on invalid backend connections.

## Related Issue

Closes #529

## Checklist

- [x] I have read the contributing guidelines
- [x] My changes are focused on the assigned issue
- [x] I have tested my changes locally
- [x] I have run linting where applicable
- [x] I have not committed sensitive files
