### PR TITLE
fix: resolve navbar overlap on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ const PastCollaborations = dynamic(() => import('@/components/home/PastCollabora
 export default function Home() {
   return (
     <>
-      <main className="min-h-screen bg-background">
+  <main className="min-h-screen bg-background pt-28">
         <FloatingParticles />
         <div className="max-w-6xl mx-auto px-4 pt-8">
           <NextBestActionWidget />

--- a/src/components/home/Hero.module.css
+++ b/src/components/home/Hero.module.css
@@ -4,7 +4,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 120px 24px 80px;
+    padding: calc(64px + 20px + 20px) 24px 80px;
     position: relative;
     overflow: hidden;
     background: transparent;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,6 +7,7 @@ import {
   Users,
   RefreshCw,
   Code,
+  Shield,
   MessageSquare,
 } from "lucide-react";
 import logo from "@/assets/logo.webp";


### PR DESCRIPTION
## Description

This PR resolves the homepage navbar overlap issue by improving the spacing between the fixed navbar and the page content.

### Changes Made
- Updated homepage layout spacing in `src/app/page.tsx`
- Adjusted Hero section padding in `Hero.module.css`
- - Added missing `Shield` import in `Footer.tsx` to resolve a runtime error encountered during local testing.

Fixes #528

## Screenshots

### Before
<img width="1321" height="1020" alt="image" src="https://github.com/user-attachments/assets/44e69375-dbc4-49d3-b8e5-ad42cb473432" />

### After
<img width="959" height="409" alt="image" src="https://github.com/user-attachments/assets/30a5024d-c5fe-440e-a6da-b12180a25366" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Local testing
1. Installed dependencies using npm install
2. Started the development server using npm run dev
3. Verified that the homepage loads successfully
4. Confirmed that the navbar no longer overlaps homepage content on initial render
5. Verified that the footer renders correctly without runtime errors

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath India" branding remains intact