### PR TITLE
feat: enhance profile DevCard

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,6 +8,7 @@ import {
   RefreshCw,
   Code,
   MessageSquare,
+  Shield,
 } from "lucide-react";
 import logo from "@/assets/logo.webp";
 import styles from "./Footer.module.css";

--- a/src/components/profile/DevCard.module.css
+++ b/src/components/profile/DevCard.module.css
@@ -263,6 +263,30 @@
   background: linear-gradient(180deg, rgba(0, 212, 255, 0.03) 0%, transparent 100%);
 }
 
+.brandLockup {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  padding: 5px 10px 5px 6px;
+  border: 1px solid var(--devcard-panel-border);
+  border-radius: 999px;
+  background: var(--devcard-panel);
+  color: var(--devcard-text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brandLogo {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  object-fit: cover;
+  box-shadow: 0 0 0 1px rgba(0, 212, 255, 0.16);
+}
+
 .avatarRing {
   position: relative;
   width: 84px;
@@ -357,6 +381,43 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.socialRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 30px;
+  width: 100%;
+}
+
+.socialLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--devcard-panel);
+  border: 1px solid var(--devcard-panel-border);
+  color: var(--devcard-text-muted);
+  transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.socialLink:hover {
+  color: #00d4ff;
+  background: rgba(0, 212, 255, 0.08);
+  border-color: rgba(0, 212, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+.socialHint {
+  color: var(--devcard-text-faint);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
 }
 
 /* ── Level progress ────────────────────────────────────────────────── */
@@ -612,11 +673,21 @@
 }
 
 .footerBrand {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.05em;
   color: rgba(0, 212, 255, 0.75);
   text-transform: uppercase;
+}
+
+.footerLogo {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  object-fit: cover;
 }
 
 .footerUrl {
@@ -699,6 +770,14 @@
     align-items: flex-start;
     flex-wrap: wrap;
     gap: 12px;
+  }
+
+  .brandLockup {
+    order: -2;
+  }
+
+  .socialRow {
+    justify-content: flex-start;
   }
 
   .meta {

--- a/src/components/profile/DevCard.tsx
+++ b/src/components/profile/DevCard.tsx
@@ -7,10 +7,11 @@ import {
   Download, Link2, Check, MapPin, Calendar,
   Trophy, Zap, Flame, Star, Award, Github,
   Layers, Code2, Globe, Users, Brain,
-  ChevronRight, Sparkles, Medal,
+  ChevronRight, Sparkles, Medal, Instagram, Linkedin,
 } from 'lucide-react';
 import { calculateLevel } from '@/lib/points';
 import { copyToClipboard } from '@/lib/clipboard';
+import { getSafeSocialUrl } from '@/lib/safe-social-url';
 import { collection, query, where, getCountFromServer } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useNotificationActions } from '@/stores/ui-store';
@@ -165,6 +166,12 @@ export default function DevCard({ user }: { user: any }) {
   const profileUrl = typeof window !== 'undefined'
     ? `${window.location.origin}/u/${user?.uid}`
     : `devpath.in/u/${user?.uid}`;
+  const socialLinks = {
+    github: getSafeSocialUrl(user?.github, 'github'),
+    linkedin: getSafeSocialUrl(user?.linkedin, 'linkedin'),
+    instagram: getSafeSocialUrl(user?.instagram, 'instagram'),
+  };
+  const hasSocialLinks = Boolean(socialLinks.github || socialLinks.linkedin || socialLinks.instagram);
 
   const waitForCardImages = async (root: HTMLElement) => {
     const imgs = Array.from(root.querySelectorAll('img'));
@@ -296,6 +303,16 @@ export default function DevCard({ user }: { user: any }) {
       >
         <div className={styles.cardInner}>
           <motion.div className={styles.leftPanel} variants={container} initial="hidden" animate="show">
+            <motion.div className={styles.brandLockup} variants={item}>
+              <Image
+                src="/DevPath-logo.webp"
+                alt="DevPath Community"
+                width={34}
+                height={34}
+                className={styles.brandLogo}
+              />
+              <span>DevPath</span>
+            </motion.div>
             <motion.div className={styles.avatarRing} variants={item}>
               <div className={styles.avatarRingInner} />
               {user?.photoURL && !avatarLoadFailed ? (
@@ -325,6 +342,26 @@ export default function DevCard({ user }: { user: any }) {
               )}
               <span className={styles.metaRow}><Calendar size={10} />Joined {fmtDate(user?.createdAt)}</span>
               {user?.githubStats?.username && <span className={styles.metaRow}><Github size={10} />{user.githubStats.username}</span>}
+            </motion.div>
+            <motion.div className={styles.socialRow} variants={item} aria-label="Dev card social links">
+              {socialLinks.github && (
+                <a href={socialLinks.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" className={styles.socialLink}>
+                  <Github size={12} />
+                </a>
+              )}
+              {socialLinks.linkedin && (
+                <a href={socialLinks.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" className={styles.socialLink}>
+                  <Linkedin size={12} />
+                </a>
+              )}
+              {socialLinks.instagram && (
+                <a href={socialLinks.instagram} target="_blank" rel="noopener noreferrer" aria-label="Instagram profile" className={styles.socialLink}>
+                  <Instagram size={12} />
+                </a>
+              )}
+              {!hasSocialLinks && (
+                <span className={styles.socialHint}>Add social links</span>
+              )}
             </motion.div>
             <motion.div className={styles.progressSection} variants={item}>
               <div className={styles.progressMeta}><span className={styles.progressLabel}>Level Progress</span><span className={styles.progressPct}>{Math.round(levelInfo.progress)}%</span></div>
@@ -375,7 +412,17 @@ export default function DevCard({ user }: { user: any }) {
           </motion.div>
 
           <div className={styles.footer}>
-            <span className={styles.footerBrand}>DevPath · Developer Network</span>
+            <span className={styles.footerBrand}>
+              <Image
+                src="/DevPath-logo.webp"
+                alt=""
+                width={18}
+                height={18}
+                className={styles.footerLogo}
+                aria-hidden="true"
+              />
+              DevPath · Developer Network
+            </span>
             <span className={styles.footerUrl}><ChevronRight size={11} style={{ opacity: 0.5 }} />devpath.in</span>
           </div>
         </div>

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -344,6 +344,21 @@ useEffect(() => {
         linkedin: getSafeSocialUrl(user.linkedin, 'linkedin'),
         instagram: getSafeSocialUrl(user.instagram, 'instagram')
     };
+    const devCardProfileKey = [
+        user.uid,
+        user.name,
+        user.photoURL,
+        user.city,
+        user.state,
+        user.github,
+        user.linkedin,
+        user.instagram,
+        user.points,
+        user.streak,
+        user.achievements?.join('|') || '',
+        user.githubStats?.username,
+        user.githubStats?.totalStars,
+    ].join(':');
 
     return (
         <div className="min-h-screen bg-background text-foreground pb-8 px-4 md:px-8">
@@ -717,7 +732,7 @@ useEffect(() => {
                             <h3 className="text-xl font-bold">Your Dev Card</h3>
                             <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full font-semibold ml-1">New</span>
                         </div>
-                        <DevCard user={user} />
+                        <DevCard key={devCardProfileKey} user={user} />
                     </div>
 
 


### PR DESCRIPTION
## Summary
- add DevPath Community logo branding to the profile DevCard header and footer
- render safe GitHub, LinkedIn, and Instagram links from the saved profile directly on the card
- refresh the DevCard when profile identity, avatar, location, social links, XP, streak, badges, or GitHub stats change
- add the missing Footer Shield icon import so the production build type-check can pass

Fixes #530

## Approach
I kept the update focused on the existing DevCard surface instead of replacing the component. The social buttons reuse the existing safe social URL helper, the logo uses the existing public DevPath asset, and the parent profile page keys the card from the profile fields that should update the card preview.

## Validation
- npm run lint -- src/components/layout/Footer.tsx
- git diff --check
- npm run build: compiled successfully and TypeScript completed after adding the missing Footer Shield import; without Firebase env vars it stops at page-data collection with the existing production guard for missing Firebase config
- npm run lint -- src/components/profile/DevCard.tsx src/components/profile/UserProfile.tsx currently reports pre-existing strict-rule issues in those files, so I kept this PR scoped instead of mixing a broad lint cleanup into the DevCard feature

## Screenshots
I could not capture an authenticated profile screenshot from this local clone because it requires a Firebase-backed login session. The rendered change is limited to the existing DevCard component and uses the current profile data/asset pipeline.