### PR TITLE
feat: make leaderboard names clickable and link to public profiles

### DIFF
--- a/src/components/gamification/Leaderboard.tsx
+++ b/src/components/gamification/Leaderboard.tsx
@@ -3,17 +3,16 @@ import { useEffect, useState } from "react";
 import { collection, query, orderBy, limit, getDocs } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { getTier } from "@/lib/gamification";
+import Link from "next/link";
 
 export function Leaderboard() {
   const [users, setUsers] = useState<any[]>([]);
   const [filter, setFilter] = useState<"alltime" | "weekly" | "monthly">("alltime");
-
   useEffect(() => {
     const field = filter === "alltime" ? "xp" : filter === "weekly" ? "weeklyXP" : "monthlyXP";
     getDocs(query(collection(db, "users"), orderBy(field, "desc"), limit(20)))
       .then(snap => setUsers(snap.docs.map(d => ({ id: d.id, ...d.data() }))));
   }, [filter]);
-
   return (
     <div>
       <div className="flex gap-2 mb-4">
@@ -35,12 +34,17 @@ export function Leaderboard() {
             <div key={u.id} className="flex items-center gap-3 p-3 bg-gray-800 rounded-xl">
               <span className="text-gray-400 w-6 text-center font-mono">#{i + 1}</span>
               <img src={u.photoURL ?? "/default-avatar.png"} className="w-8 h-8 rounded-full" />
-              <span className="flex-1 font-medium">{u.displayName ?? "Anonymous"}</span>
+              <Link
+                href={`/u/${u.id}`}
+                className="flex-1 font-medium hover:text-cyan-400 transition-colors cursor-pointer"
+              >
+                {u.displayName ?? "Anonymous"}
+              </Link>
               <span className="text-xs px-2 py-0.5 rounded-full font-bold"
                 style={{ color: tier.color, border: `1px solid ${tier.color}` }}>
                 {tier.name}
               </span>
-              <span className="text-yellow-400 font-bold text-sm">{u.xp ?? 0} XP</span>
+              <span className="text-yellow-400 font-bold text-sm">{u.xp?? 0} XP</span>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

Leaderboard names on /pathway were plain text with no interactivity. This PR makes them clickable and adds hover color feedback.

## Changes Made

Wrapped each leaderboard user's name in a <Link> component pointing to /u/${u.id} (the existing public profile route)
Added hover:text-cyan-400 transition-colors for smooth color change on hover

## Testing Checklist

- Hovering over a name changes its color to cyan
- Clicking a name navigates to /u/[uid] public profile page
- Works for all time / weekly / monthly filter tabs
- No TypeScript errors or console warnings

Closes #531 