### PR TITLE
fix(security): resolve tab nabbing vulnerability on external github l…

### DIFF
--- a/src/components/profile/GithubStats.tsx
+++ b/src/components/profile/GithubStats.tsx
@@ -144,7 +144,7 @@ export default function GithubStats({ user }: { user: any }) {
                                             {event.type.replace('Event', '').replace(/([A-Z])/g, ' $1').trim()}
                                         </span>
                                         {' '}on{' '}
-                                        <a href={event.repo.url} target="_blank" className="text-primary hover:underline font-medium">
+                                        <a href={event.repo.url} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline font-medium">
                                             {event.repo.name}
                                         </a>
                                     </p>


### PR DESCRIPTION
# 🚀 Security Fix: Resolve Cross-Site Tab Nabbing Vulnerability 

## 🎯 What does this PR do?
This pull request addresses a critical security vulnerability within `GithubStats.tsx`.

Previously, external anchor links originating from user-generated GitHub activity data were being opened in a new tab (`target="_blank"`) without the standard security attribute `rel="noopener noreferrer"`. This exposes the application to a class of attack known as Reverse Tab Nabbing, where the newly opened window can use the `window.opener` object to hijack the original tab and silently redirect it to a malicious phishing site.

## 🛠️ Technical Implementation
- Appended `rel="noopener noreferrer"` to the external `<a href={event.repo.url}>` tag inside `src/components/profile/GithubStats.tsx`. 

### 📝 Code Changes
```diff
--- a/src/components/profile/GithubStats.tsx
+++ b/src/components/profile/GithubStats.tsx
@@ -144,7 +144,7 @@
                                             {event.type.replace('Event', '').replace(/([A-Z])/g, ' $1').trim()}
                                         </span>
                                         {' '}on{' '}
-                                        <a href={event.repo.url} target="_blank" className="text-primary hover:underline font-medium">
+                                        <a href={event.repo.url} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline font-medium">
                                             {event.repo.name}
                                         </a>
                                     </p>
```

## 🐛 Bug Details
- **Severity:** High / Security
- **Symptoms:** None visible to the user, but leaves the application dangerously exposed to XSS-style window-hijacking attacks. 

## ✅ Verification
1. Navigate to a User Profile that has connected their GitHub account and has recent GitHub Activity (e.g., PushEvents).
2. Inspect the "Recent Contributions" links in the browser Developer Tools.
3. Validate that the HTML output correctly contains `rel="noopener noreferrer"`.
4. Click the link and confirm that the `window.opener` context in the new tab is `null`.


Closes #499 
