### PR TITLE
Fix footer mobile layout (Fixes #580)

### DIFF
--- a/src/components/layout/Footer.module.css
+++ b/src/components/layout/Footer.module.css
@@ -62,9 +62,16 @@
 }
 
 @media (max-width: 768px) {
+  .links {
+    align-items: center;
+  }
+  .link {
+    justify-content: center;
+  }
   .bottom {
     flex-direction: column;
     gap: 20px;
     text-align: center;
+    align-items: center;
   }
 }


### PR DESCRIPTION
This PR centers the footer links and social icons on mobile devices for a consistent layout.

Fixes #580
Hi @devpathindcommunity-india,
  I have submitted a PR for this issue under GSSoC 2026.