### PR TITLE
fix: resolve cascading renders and optimistic UI race conditions in u…

### DIFF
--- a/src/hooks/useLearningProgress.ts
+++ b/src/hooks/useLearningProgress.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
@@ -35,7 +35,7 @@ export function useLearningProgress(): UseLearningProgressResult {
         setLoading(false);
       },
       (error) => {
-        console.error("Error listening to learning progress:", error);
+        console.error('Error listening to learning progress:', error);
         setLoading(false);
       }
     );
@@ -72,7 +72,7 @@ export function useLearningProgress(): UseLearningProgressResult {
         { merge: true }
       );
     } catch (error) {
-      console.error("Failed to save learning progress:", error);
+      console.error('Failed to save learning progress:', error);
     }
   };
 

--- a/src/hooks/useLearningProgress.ts
+++ b/src/hooks/useLearningProgress.ts
@@ -19,12 +19,9 @@ export function useLearningProgress(): UseLearningProgressResult {
 
   useEffect(() => {
     if (!user) {
-      setCompletedNodes([]);
-      setLoading(false);
       return;
     }
 
-    setLoading(true);
     const docRef = doc(db, 'user_progress', user.uid);
     const unsubscribe = onSnapshot(
       docRef,
@@ -46,20 +43,23 @@ export function useLearningProgress(): UseLearningProgressResult {
     return () => unsubscribe();
   }, [user]);
 
+  // Derive state based on user authentication status to avoid cascading renders
+  const actualCompletedNodes = user ? completedNodes : [];
+  const actualLoading = user ? loading : false;
+
   const toggleNode = async (pathId: string, nodeId: string) => {
     if (!user) return;
 
     const nodeKey = `${pathId}-${nodeId}`;
-    const isCompleted = completedNodes.includes(nodeKey);
+    const isCompleted = actualCompletedNodes.includes(nodeKey);
 
-    // Optimistic UI Update: Reflect state immediately in local array
-    const previousCompletedNodes = [...completedNodes];
     const nextCompletedNodes = isCompleted
-      ? completedNodes.filter((id) => id !== nodeKey)
-      : [...completedNodes, nodeKey];
+      ? actualCompletedNodes.filter((id) => id !== nodeKey)
+      : [...actualCompletedNodes, nodeKey];
 
-    setCompletedNodes(nextCompletedNodes);
-
+    // Rely exclusively on Firestore's native latency compensation (which instantly triggers
+    // the onSnapshot listener locally) instead of manually maintaining optimistic state
+    // which leads to race conditions.
     try {
       const docRef = doc(db, 'user_progress', user.uid);
       await setDoc(
@@ -73,18 +73,16 @@ export function useLearningProgress(): UseLearningProgressResult {
       );
     } catch (error) {
       console.error("Failed to save learning progress:", error);
-      // Revert state on error if background write fails
-      setCompletedNodes(previousCompletedNodes);
     }
   };
 
   const isNodeCompleted = (pathId: string, nodeId: string) => {
-    return completedNodes.includes(`${pathId}-${nodeId}`);
+    return actualCompletedNodes.includes(`${pathId}-${nodeId}`);
   };
 
   return {
-    completedNodes,
-    loading,
+    completedNodes: actualCompletedNodes,
+    loading: actualLoading,
     toggleNode,
     isNodeCompleted,
   };


### PR DESCRIPTION
# PR: Fix React Anti-Patterns in `useLearningProgress`

# Closes #606 

## Title
fix: resolve cascading renders and optimistic UI race conditions in `useLearningProgress`

## Description
**Issue:**
1. **Cascading Renders**: The hook previously called `setCompletedNodes([])` and `setLoading(false)` synchronously within the `useEffect` body when an unauthenticated user was detected. This violated React guidelines and caused the `react-hooks/set-state-in-effect` linter error.
2. **Race Conditions**: The `toggleNode` function employed manual local state updates (Optimistic UI) which conflicted with the `onSnapshot` listener's built-in latency compensation. This caused duplicate state triggers and potential race conditions if a network update failed.

**Fix:**
- Derived the fallback empty state dynamically using standard JS ternary operators based on the `user` context variable instead of firing synchronous state mutations inside the `useEffect`.
- Removed `setLoading(true)` from the hook's effect body (as `loading` initializes to `true` globally, and the cleanup routine or subsequent `onSnapshot` adequately manages its transitions).
- Stripped the manual optimistic UI updates from `toggleNode`, completely deferring to Firestore's native `onSnapshot` latency compensation which safely handles instantaneous local updates out-of-the-box.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (performance improvements)

## Testing
- [x] Ran `npx eslint src/hooks/useLearningProgress.ts` locally and verified that the `react-hooks/set-state-in-effect` rule is no longer violated.
- [x] TypeScript compilation passes flawlessly.
