### PR TITLE
feat: add Load More pagination to Project Showcase section

### DIFF
--- a/src/components/profile/ProjectShowcaseSection.tsx
+++ b/src/components/profile/ProjectShowcaseSection.tsx
@@ -1,6 +1,7 @@
 // src/components/profile/ProjectShowcaseSection.tsx
 'use client';
 
+import { useState } from 'react';
 import { ExternalLink, Github } from 'lucide-react';
 import type { PortfolioProject } from '@/types/portfolio';
 
@@ -8,8 +9,15 @@ interface Props {
   projects: PortfolioProject[];
 }
 
+const ITEMS_PER_PAGE = 6;
+
 export function ProjectShowcaseSection({ projects }: Props) {
+  const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
+
   if (!projects?.length) return null;
+
+  const visibleProjects = projects.slice(0, visibleCount);
+  const hasMore = visibleCount < projects.length;
 
   return (
     <section>
@@ -22,10 +30,24 @@ export function ProjectShowcaseSection({ projects }: Props) {
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {projects.map((project) => (
+        {visibleProjects.map((project) => (
           <ProjectCard key={project.nodeId} project={project} />
         ))}
       </div>
+      {hasMore && (
+        <div className="flex justify-center mt-6">
+          <button
+            onClick={() =>
+              setVisibleCount((prev) =>
+                Math.min(prev + ITEMS_PER_PAGE, projects.length)
+              )
+            }
+            className="px-5 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-sm font-medium text-white transition-colors"
+          >
+            Load More ({projects.length - visibleCount} remaining)
+          </button>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Closes #639 #634 

## Scope Note
While investigating this issue, I found that the **Resources section** (`ResourcesTabs.tsx`, roadmaps tab) already has a working IntersectionObserver-based infinite scroll implementation (`visibleCount`, `ITEMS_PER_PAGE`, `observerRef`), so no changes were needed there.

The **Project Showcase section** (`ProjectShowcaseSection.tsx`), however, was rendering all projects at once with no pagination. This PR addresses that gap.

## Changes Made
- Added a `visibleCount` state initialized to `6` items
- Projects are now sliced (`projects.slice(0, visibleCount)`) instead of rendering the full list
- Added a **"Load More"** button that appears only when more projects exist beyond the currently visible count, showing how many remain
- Clicking "Load More" reveals 6 more projects at a time until all are shown

## Why this approach?
A "Load More" button was chosen over IntersectionObserver here because:
- It's simpler and avoids adding extra observer/ref boilerplate for what is typically a smaller, finite list (project showcases)
- It matches one of the two acceptable approaches explicitly suggested in the issue
- It keeps the component fully presentational (no other state/side-effects needed)

## How to test?
1. Visit a public profile page: `/profile/<username>`
2. If the user has more than 6 verified projects, only the first 6 should render initially, with a "Load More (X remaining)" button below
3. Clicking the button reveals the next batch of projects until all are visible (button then disappears)
4. If a user has 6 or fewer projects, the button should not appear at all

## Type of Change
- [x] Feature (non-breaking)