### PR TITLE
fix(auth): prevent infinite loading hang on Firestore snapshot error

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -338,6 +338,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 setUser(updatedUser as User);
               }
               setIsLoading(false);
+            },
+            (error) => {
+              console.error('Firestore user sync error:', error);
+              setIsLoading(false);
             }
           );
 

--- a/src/context/__tests__/AuthContext.test.tsx
+++ b/src/context/__tests__/AuthContext.test.tsx
@@ -1,10 +1,20 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../AuthContext';
 
 const mockSignIn = jest.fn();
 const mockSignOut = jest.fn();
+const mockOnAuthStateChanged = jest.fn(() => jest.fn());
+const mockOnSnapshot = jest.fn(
+  (
+    _ref: unknown,
+    cb: (snapshot: { exists: () => boolean; data?: () => Record<string, unknown> }) => void
+  ) => {
+    cb({ exists: () => false });
+    return jest.fn();
+  }
+);
 
 const firebaseMock = {
   auth: {},
@@ -15,7 +25,7 @@ const firebaseMock = {
 
 jest.mock('firebase/auth', () => ({
   getAuth: () => ({}),
-  onAuthStateChanged: jest.fn(() => jest.fn()),
+  onAuthStateChanged: (...args: unknown[]) => mockOnAuthStateChanged(...args),
   signInWithEmailAndPassword: (...args: unknown[]) => mockSignIn(...args),
   signOut: (...args: unknown[]) => mockSignOut(...args),
   setPersistence: jest.fn(() => Promise.resolve()),
@@ -41,12 +51,11 @@ jest.mock('firebase/firestore', () => ({
   doc: jest.fn(() => ({})),
   getDoc: jest.fn(() => Promise.resolve({ exists: () => false })),
   setDoc: jest.fn(() => Promise.resolve()),
-  onSnapshot: jest.fn(
-    (_ref: unknown, cb: (snapshot: { exists: () => boolean }) => void) => {
-      cb({ exists: () => false });
-      return jest.fn();
-    }
-  ),
+  onSnapshot: (
+    ref: unknown,
+    cb: (snapshot: { exists: () => boolean; data?: () => Record<string, unknown> }) => void,
+    errorCb?: (error: Error) => void
+  ) => mockOnSnapshot(ref, cb, errorCb),
   writeBatch: jest.fn(() => ({
     commit: jest.fn(),
     set: jest.fn(),
@@ -76,7 +85,7 @@ jest.mock('@/lib/points', () => ({
 }));
 
 function TestHarness() {
-  const { user, login, logout } = useAuth();
+  const { user, isLoading, login, logout } = useAuth();
   const [error, setError] = React.useState<string | null>(null);
   const handleLogin = async () => {
     try {
@@ -89,6 +98,7 @@ function TestHarness() {
     <div>
       <span data-testid="user-email">{user?.email || 'null'}</span>
       <span data-testid="error">{error || ''}</span>
+      <span data-testid="loading-status">{isLoading ? 'loading' : 'done'}</span>
       <button data-testid="login-btn" onClick={handleLogin}>
         login
       </button>
@@ -110,6 +120,16 @@ function renderWithAuth() {
 beforeEach(() => {
   jest.clearAllMocks();
   localStorage.clear();
+  mockOnAuthStateChanged.mockImplementation(() => jest.fn());
+  mockOnSnapshot.mockImplementation(
+    (
+      _ref: unknown,
+      cb: (snapshot: { exists: () => boolean; data?: () => Record<string, unknown> }) => void
+    ) => {
+      cb({ exists: () => false });
+      return jest.fn();
+    }
+  );
 });
 
 describe('AuthContext', () => {
@@ -205,6 +225,64 @@ describe('AuthContext', () => {
       );
 
       firebaseMock.firebaseAvailable = true;
+    });
+  });
+
+  describe('Firestore onSnapshot loading state', () => {
+    it('sets isLoading to false when Firestore sync succeeds', async () => {
+      mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: { uid: string; email: string | null; displayName: string | null } | null) => void) => {
+        callback({ uid: 'test-uid', email: 'test@example.com', displayName: 'Test User' });
+        return jest.fn();
+      });
+
+      mockOnSnapshot.mockImplementation(
+        (
+          _ref: unknown,
+          cb: (snapshot: { exists: () => boolean; data?: () => Record<string, unknown> }) => void
+        ) => {
+          cb({
+            exists: () => true,
+            data: () => ({
+              role: 'member',
+              points: 100,
+            }),
+          });
+          return jest.fn();
+        }
+      );
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-status')).toHaveTextContent('done');
+      });
+      expect(screen.getByTestId('user-email')).toHaveTextContent('test@example.com');
+    });
+
+    it('sets isLoading to false and does not hang when Firestore sync fails', async () => {
+      mockOnAuthStateChanged.mockImplementation((_auth: unknown, callback: (user: { uid: string; email: string | null; displayName: string | null } | null) => void) => {
+        callback({ uid: 'test-uid-error', email: 'test-error@example.com', displayName: 'Test User Error' });
+        return jest.fn();
+      });
+
+      mockOnSnapshot.mockImplementation(
+        (
+          _ref: unknown,
+          _cb: (snapshot: { exists: () => boolean; data?: () => Record<string, unknown> }) => void,
+          errorCb?: (error: Error) => void
+        ) => {
+          if (errorCb) {
+            errorCb(new Error('Mocked Firestore Permission Denied'));
+          }
+          return jest.fn();
+        }
+      );
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-status')).toHaveTextContent('done');
+      });
     });
   });
 });


### PR DESCRIPTION
### Problem
The Firestore `onSnapshot` listener in `src/context/AuthContext.tsx` lacked an error callback. Currently, `setIsLoading(false)` is only called inside the success callback. If the snapshot fails during initialization (due to permission issues, network interruptions, deleted document, or Firestore errors), the success callback is never executed and the application remains stuck in a loading spinner state indefinitely.

### Solution
- Added the standard third-parameter error callback to the Firestore `onSnapshot` listener.
- Ensured `setIsLoading(false)` is called upon error to resolve the loading spinner state and logged the sync error to the console.
- Updated `src/context/__tests__/AuthContext.test.tsx` by mocking both `onSnapshot` success and failure conditions to guarantee that `setIsLoading(false)` resolves properly in all cases.

### Verification Results
- **Unit Tests (`npm test`)**: All 19 tests passed, including new test cases for loading-state resolution.
- **E2E Tests (`npm run test:e2e`)**: All 28 Playwright tests passed successfully.
- **Production Build (`npm run build`)**: Compiled successfully with complete TypeScript and Next.js static asset checks.
- **Linter Check**: Passed cleanly on modified files.

closes #686
