### PR TITLE
fix: Prevent AI Chatbot FAB from overlapping footer social icons

### DIFF
--- a/src/components/layout/Footer.module.css
+++ b/src/components/layout/Footer.module.css
@@ -49,6 +49,7 @@
 .socials {
   display: flex;
   gap: 20px;
+  padding-right: 85px; 
 }
 
 .socialIcon {


### PR DESCRIPTION
## Description
Added `padding-right: 80px` to the `.socials` class in `Footer.module.css` to prevent the floating AI chatbot button (FAB) from overlapping the GitHub, LinkedIn, and Instagram social icons in the footer.

Fixes #693 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local testing

Verified on `localhost:3000` — scrolled to footer, confirmed social icons are fully visible and no longer overlapped by the chatbot FAB.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

Before:

<img width="1591" height="333" alt="image" src="https://github.com/user-attachments/assets/8c12f8fc-1d57-4de0-b0fc-fca75c933475" />

After:


<img width="1581" height="307" alt="image" src="https://github.com/user-attachments/assets/56a44897-01d1-47d4-bdd0-329504d55b81" />
