### PR TITLE
fix(layout): resolve blank page rendering on fresh reload (F5)

### DIFF
--- a/src/components/layout/MaintenanceBlocker.tsx
+++ b/src/components/layout/MaintenanceBlocker.tsx
@@ -12,14 +12,19 @@ export default function MaintenanceBlocker({
   const { isMaintenanceMode, loading: maintenanceLoading } = useMaintenance();
   const { user, isLoading: authLoading } = useAuth();
 
-  // If still checking database or auth, show nothing or a tiny spinner
-  if (maintenanceLoading || authLoading) return null;
+  const isLoading = maintenanceLoading || authLoading;
 
-  // THE CORE LOGIC: If maintenance is ON and user is NOT an admin, BLOCK THEM.
-  if (isMaintenanceMode && !(user as any)?.isAdmin) {
+  // If maintenance is ON and user is NOT an admin, BLOCK THEM.
+  if (!isLoading && isMaintenanceMode && !(user as any)?.isAdmin) {
     return <MaintenanceOverlay />;
   }
 
-  // Otherwise, let them see the site normally
-  return <>{children}</>;
+  return (
+    <div
+      className={isLoading ? 'opacity-0 pointer-events-none' : ''}
+      aria-hidden={isLoading}
+    >
+      {children}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where refreshing the browser (F5) or directly visiting routes such as `/`, `/profile`, `/community`, and `/pathway` displayed only the Navbar and Footer while the main page content remained blank.

## Root Cause

`MaintenanceBlocker` returned `null` during the initial authentication and maintenance loading state, causing the layout children to be skipped during SSR and hydration.

## Solution

* Updated `MaintenanceBlocker` to always render layout children.
* Wrapped children in a container that remains visually hidden and non-interactive while loading.
* Preserved the existing maintenance mode and authentication behavior.
* Maintained a consistent DOM structure during SSR and hydration to prevent blank page rendering.

## Testing

* Verified the homepage (`/`) renders correctly after a browser refresh.
* Verified `/profile`, `/community`, and `/pathway` render correctly after refresh.
* Confirmed the project builds successfully with `npm run build`.

## Type of Change

* [x] Bug Fix
