### PR TITLE
fix: add scroll-to-top button to all pages (closes #729)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@ import { SectionDivider } from '@/components/SectionDivider';
 import { SectionEntrance } from '@/components/ui/SectionEntrance';
 import { FloatingParticles } from '@/components/FloatingParticles';
 import dynamic from 'next/dynamic';
-import BackToTop from '@/components/BackToTop';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import CookieConsent from '@/components/CookieConsent';
 
@@ -39,8 +38,6 @@ export default function Home() {
             <Sponsors />
           </SectionEntrance>
         </ErrorBoundary>
-
-        <BackToTop />
 
         {/* COOKIE CONSENT GLOBAL POPUP */}
         <CookieConsent />

--- a/src/components/layout/RouteAwareChrome.tsx
+++ b/src/components/layout/RouteAwareChrome.tsx
@@ -14,6 +14,7 @@ import { ToastContainer } from '@/components/ui/ToastContainer';
 import SearchModal from '@/components/layout/SearchModal';
 import ShortcutLegend from '@/components/layout/ShortcutLegend';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import BackToTop from '@/components/BackToTop';
 
 export default function RouteAwareChrome({
   children,
@@ -24,7 +25,6 @@ export default function RouteAwareChrome({
   const isAuthRoute = pathname === '/login' || pathname === '/signup';
   const [isLegendOpen, setLegendOpen] = useState(false);
 
-  // Bind global navigation shortcuts
   useKeyboardShortcuts({
     '?': () => setLegendOpen((prev) => !prev),
     escape: () => setLegendOpen(false),
@@ -42,6 +42,7 @@ export default function RouteAwareChrome({
 
       {!isAuthRoute && <FooterWrapper />}
       {!isAuthRoute && <FloatingAssistant />}
+      {!isAuthRoute && <BackToTop />}
       <ToastContainer />
       <SearchModal />
       <ShortcutLegend


### PR DESCRIPTION
## Fixes #729

The BackToTop component was only rendered inside the Home page (src/app/page.tsx), so no other route had a scroll-to-top button.

### Changes
- Moved <BackToTop /> into RouteAwareChrome.tsx, the shared layout wrapper rendered on every route
- Removed the now-duplicate <BackToTop /> usage from src/app/page.tsx
- Excluded it from /login and /signup to match existing behavior for footer/assistant

### Testing
- Ran npm run dev and confirmed the button now appears after scrolling on non-Home pages (e.g. /resources)
- Confirmed it still works correctly on Home with no duplicate render