### PR TITLE
fix: extract correct credential for Google and GitHub in account linking

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -223,7 +223,9 @@ export default function LoginPage() {
       console.error(err);
 
       if (err?.code === 'auth/account-exists-with-different-credential') {
-        const credential = OAuthProvider.credentialFromError(err);
+        const credential = providerName === 'google' 
+          ? GoogleAuthProvider.credentialFromError(err) 
+          : GithubAuthProvider.credentialFromError(err);
         const email = err.customData?.email;
         if (email && credential) {
           setLinkingEmail(email);


### PR DESCRIPTION
Fixes the issue where users see 'Unable to sign in' instead of the account linking UI because we were using OAuthProvider instead of the specific Google/GitHub provider to extract the pending credential.