### PR TITLE
Fix infinite XP farming in determineBadges

### DIFF
--- a/src/lib/__tests__/point-calculation.test.ts
+++ b/src/lib/__tests__/point-calculation.test.ts
@@ -52,4 +52,21 @@ describe('point calculation', () => {
     expect(result.achievements).toContain('streak-7');
     expect(result.points).toBeNull();
   });
+
+  it('preserves existing badges even if criteria is no longer met', () => {
+    const userWithPastAchievements = {
+      uid: 'member-1',
+      // User deleted their bio and role, so they normally wouldn't get profile-perfect
+      name: 'DevPath Member',
+      photoURL: '/avatar.png',
+      // But they already earned it in the past
+      achievements: ['profile-perfect', 'storyteller'],
+    };
+
+    const badges = determineBadges(userWithPastAchievements, []);
+    expect(badges).toContain('profile-perfect');
+    expect(badges).toContain('storyteller');
+    // Sanity check: they shouldn't randomly get a badge they didn't earn
+    expect(badges).not.toContain('local-hero');
+  });
 });

--- a/src/lib/point-calculation.ts
+++ b/src/lib/point-calculation.ts
@@ -74,36 +74,38 @@ export function determineBadges(
   user: UserData,
   projects: ProjectData[]
 ): string[] {
-  const earned: string[] = [];
+  // Start with existing achievements to ensure permanent badges are not lost
+  const earned: string[] = user.achievements ? [...user.achievements] : [];
 
-  // Early Adopter is time-limited — preserve if already held
-  if (user.achievements?.includes('early-adopter')) {
-    earned.push('early-adopter');
-  }
+  // Helper to safely add badges without duplicating
+  const award = (badge: string) => {
+    if (!earned.includes(badge)) {
+      earned.push(badge);
+    }
+  };
 
   // Profile completeness
   if (user.name && user.bio && user.photoURL && user.role)
-    earned.push('profile-perfect');
-  if (user.bio && user.bio.length > 20) earned.push('storyteller');
-  if (user.photoURL) earned.push('face-of-community');
-  if (user.city || user.state) earned.push('local-hero');
+    award('profile-perfect');
+  if (user.bio && user.bio.length > 20) award('storyteller');
+  if (user.photoURL) award('face-of-community');
+  if (user.city || user.state) award('local-hero');
 
   // Social links
-  if (user.github && user.linkedin && user.instagram)
-    earned.push('connector-social');
-  if (user.github) earned.push('social-github');
-  if (user.linkedin) earned.push('social-linkedin');
-  if (user.instagram) earned.push('social-instagram');
+  if (user.github && user.linkedin && user.instagram) award('connector-social');
+  if (user.github) award('social-github');
+  if (user.linkedin) award('social-linkedin');
+  if (user.instagram) award('social-instagram');
 
   // Projects
   const projectCount = projects.length;
-  if (projectCount >= 1) earned.push('builder-1');
-  if (projectCount >= 3) earned.push('builder-3');
-  if (projectCount >= 5) earned.push('builder-5');
-  if (projectCount >= 10) earned.push('builder-10');
+  if (projectCount >= 1) award('builder-1');
+  if (projectCount >= 3) award('builder-3');
+  if (projectCount >= 5) award('builder-5');
+  if (projectCount >= 10) award('builder-10');
 
   // Streak
-  if ((user.streak || 0) >= 7) earned.push('streak-7');
+  if ((user.streak || 0) >= 7) award('streak-7');
 
   return earned;
 }


### PR DESCRIPTION
# Fix infinite XP farming vulnerability in gamification engine

## Description
This PR fixes a critical logical vulnerability in `determineBadges` that allowed users to farm infinite Dev Points. Previously, the gamification engine dynamically recalculated earned badges from scratch based on the user's current profile state without considering previously unlocked achievements. 

Because `determineBadges` didn't preserve most already-earned badges, a user could delete their bio (losing the `profile-perfect` badge in the output) and re-add it, causing the backend to see it as a newly unlocked badge and award duplicate XP. 

This update preserves any existing badges in the user's `achievements` array by pre-populating the `earned` array before checking criteria, ensuring badges (and the resulting XP) can only be earned once.

## Changes
- **`src/lib/point-calculation.ts`**: Updated `determineBadges` to initialize the `earned` array with `user.achievements` and created a safe `award` helper that prevents pushing duplicate badges.
- **`src/lib/__tests__/point-calculation.test.ts`**: Added a new unit test to explicitly verify that previously earned badges are preserved even if the user no longer meets their criteria (e.g., after deleting their bio).

## Verification
- [x] Unit tests updated and verified.
- [x] Tested that deleting bio/role no longer revokes existing `profile-perfect` badge.
- [x] Ensured newly added achievements are appended correctly.

## Related Issues
- Resolves Issue: Infinite XP Farming Vulnerability in `determineBadges()` 
Closes #672 
