### PR TITLE
Fix hydration mismatch in useReducedMotion

### DIFF
--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -13,16 +13,16 @@ import { useEffect, useState } from 'react';
  *   const shouldReduceMotion = useReducedMotion();
  */
 export function useReducedMotion(): boolean {
-  const [reducedMotion, setReducedMotion] = useState<boolean>(() => {
-    // SSR-safe: default to false on server
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  });
+  // Always initialize to false to match the server render and avoid hydration mismatch
+  const [reducedMotion, setReducedMotion] = useState<boolean>(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    // Set initial value once mounted on client
+    setReducedMotion(mediaQuery.matches);
 
     const handleChange = (event: MediaQueryListEvent) => {
       setReducedMotion(event.matches);


### PR DESCRIPTION
# Fix React Hydration Mismatch in useReducedMotion

## Description
This PR resolves a React Hydration Mismatch error caused by the `useReducedMotion` hook. Previously, the hook attempted to synchronously evaluate `window.matchMedia` during the initial client-side render's `useState` callback. If a user had "prefers-reduced-motion" enabled on their OS, the client evaluated to `true`, conflicting with the server-rendered `false`, resulting in hydration errors and potential UI flickering.

This fix unconditionally defaults the initial state to `false` (matching the server) and relies on the `useEffect` hook to safely evaluate and update the user's OS preference once the component has successfully mounted on the client.

## Changes
- **`src/hooks/useReducedMotion.ts`**: Modified state initialization to always return `false`. Added logic inside the `useEffect` hook to explicitly set the correct value derived from `window.matchMedia` immediately upon mounting, before listening to changes.

## Verification
- [x] Tested that toggling the motion setting on the OS updates the React state dynamically without requiring a page refresh.
- [x] Tested with "prefers-reduced-motion" enabled on OS to verify hydration mismatch warnings no longer appear in the console.

## Related Issues
- Resolves Issue: React Hydration Mismatch in `useReducedMotion.ts`
Closes #669 