### PR TITLE
fix: fix the back to top button overlapping with footer elements on small devices

### DIFF
--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -30,7 +30,7 @@ const BackToTop = (): React.ReactElement | null => {
   return (
     <AnimatePresence>
       {isVisible && (
-        <div className="fixed bottom-28 right-11 z-50">
+        <div className="fixed right-4 bottom-40 sm:right-6 sm:bottom-36 md:right-11 md:bottom-28 z-50">
           <motion.button
             onClick={scrollToTop}
             initial={{ opacity: 0, y: 50 }}


### PR DESCRIPTION


## Description

Added `<div className="fixed right-4 bottom-40 sm:right-6 sm:bottom-36 md:right-11 md:bottom-28 z-50">`  in `BackToTop.tsx` in place of `<div className="fixed bottom-28 right-11 z-50">` at line `33` to fix the issue which caused the back to top button interfering with the footer texts.

Fixes #749 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

- [x] Local testing
- [ ] Vercel Preview Deployment

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked that the "DevPath Bharat" branding remains intact
