### PR TITLE
fix(a11y): add rel=noopener noreferrer to external links 

### DIFF
--- a/src/app/contributors/guidelines.tsx
+++ b/src/app/contributors/guidelines.tsx
@@ -121,6 +121,7 @@ export default function GuidelinesPage() {
               <a
                 href="https://github.com/devpathindcommunity-india/DevPath-Web"
                 target="_blank"
+                rel="noopener noreferrer"
                 className="border border-white/30 hover:bg-white/10 px-8 py-4 rounded-2xl font-medium transition-all flex items-center gap-3"
               >
                 View Repository
@@ -175,6 +176,7 @@ export default function GuidelinesPage() {
                 <a
                   href="https://github.com/devpathindcommunity-india/DevPath-Web/issues"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="block hover:text-white transition-colors flex items-center gap-2"
                 >
                   <Bug className="w-4 h-4" /> Report an Issue
@@ -182,6 +184,7 @@ export default function GuidelinesPage() {
                 <a
                   href="https://github.com/devpathindcommunity-india/DevPath-Web/pulls"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="block hover:text-white transition-colors flex items-center gap-2"
                 >
                   <Star className="w-4 h-4" /> Open PRs

--- a/src/app/opensource/page.tsx
+++ b/src/app/opensource/page.tsx
@@ -491,6 +491,7 @@ export default function OpenSourcePage() {
               <Link
                 href="https://github.com"
                 target="_blank"
+                rel="noopener noreferrer"
                 className="text-primary text-sm font-medium flex items-center gap-1 hover:underline"
               >
                 Visit Platform <ExternalLink size={14} />
@@ -510,6 +511,7 @@ export default function OpenSourcePage() {
               <Link
                 href="https://gitlab.com"
                 target="_blank"
+                rel="noopener noreferrer"
                 className="text-orange-500 text-sm font-medium flex items-center gap-1 hover:underline"
               >
                 Visit Platform <ExternalLink size={14} />
@@ -529,6 +531,7 @@ export default function OpenSourcePage() {
               <Link
                 href="https://bitbucket.org"
                 target="_blank"
+                rel="noopener noreferrer"
                 className="text-blue-500 text-sm font-medium flex items-center gap-1 hover:underline"
               >
                 Visit Platform <ExternalLink size={14} />
@@ -590,6 +593,7 @@ export default function OpenSourcePage() {
                 <Link
                   href="https://opensource.guide/how-to-contribute/"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center justify-between p-3 bg-card rounded-lg hover:border-primary border border-transparent transition-colors group"
                 >
                   <span className="font-medium">
@@ -605,6 +609,7 @@ export default function OpenSourcePage() {
                 <Link
                   href="https://goodfirstissue.dev/"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center justify-between p-3 bg-card rounded-lg hover:border-primary border border-transparent transition-colors group"
                 >
                   <span className="font-medium">Good First Issues</span>
@@ -618,6 +623,7 @@ export default function OpenSourcePage() {
                 <Link
                   href="https://firstcontributions.github.io/"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center justify-between p-3 bg-card rounded-lg hover:border-primary border border-transparent transition-colors group"
                 >
                   <span className="font-medium">First Contributions Guide</span>

--- a/src/app/u/client.tsx
+++ b/src/app/u/client.tsx
@@ -841,6 +841,7 @@ function ProfileContent({ uid }: { uid?: string }) {
                                 aria-label="Link"
                                 href={event.repo.url}
                                 target="_blank"
+                                rel="noopener noreferrer"
                                 className="text-primary hover:underline font-medium"
                               >
                                 {event.repo.name}
@@ -1050,7 +1051,12 @@ function ProfileContent({ uid }: { uid?: string }) {
                     <div className="flex items-center justify-between pt-3 border-t border-border">
                       <div className="flex items-center gap-4">
                         <button
-                          aria-label={currentUser && project.likes.includes(currentUser.uid) ? "Unlike project" : "Like project"}
+                          aria-label={
+                            currentUser &&
+                            project.likes.includes(currentUser.uid)
+                              ? 'Unlike project'
+                              : 'Like project'
+                          }
                           onClick={() =>
                             handleLikeProject(project.id, project.likes)
                           }


### PR DESCRIPTION
## Summary
Audited every `target="_blank"` anchor and `Link` component across `src/` for the missing `rel="noopener noreferrer"` attribute described in #753. This closes a reverse-tabnabbing security gap and resolves the associated Lighthouse best-practices penalty.

## Audit method
Ran a recursive scan across all `.tsx`/`.ts` files checking a few lines of context around every `target="_blank"` occurrence for an accompanying `rel="noopener noreferrer"`. Confirmed `src/components/` was already fully compliant (30/30 links had the attribute). The actual gaps were found in `src/app/`.

## Changes
Added `rel="noopener noreferrer"` to the following previously-unprotected external links:

- `src/app/contributors/guidelines.tsx` — "View Repository", "Report an Issue", and "Open PRs" links
- `src/app/opensource/page.tsx` — platform links (GitHub, GitLab, Bitbucket) and contributor-resource links (Open Source Guide, Good First Issues, First Contributions)
- `src/app/u/client.tsx` — GitHub activity feed repo link

No behavioral changes — links still open in a new tab exactly as before; this only adds the missing security/accessibility attribute.

## How to test
1. Run `npm run dev`
2. Visit `/contributors/guidelines`, `/opensource`, and a user profile page under `/u/[username]`
3. Confirm all external links still open correctly in a new tab
4. Inspect the DOM (or view source) to confirm `rel="noopener noreferrer"` is present on each `target="_blank"` element

## Checklist
- [x] Audited all of `src/` (not just `src/components/`, since that folder was already compliant)
- [x] Verified no missing `rel` attributes remain via automated scan
- [x] No console errors or warnings introduced
- [x] External links tested manually and open as expected

## Related Issue
Closes #753