### PR TITLE
refactor: convert CookieConsent.jsx to TypeScript

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 
 const COOKIE_KEY = 'cookie_consent';
 
-export default function CookieConsent() {
-  const [visible, setVisible] = useState(false);
+type ConsentValue = 'accepted' | 'rejected';
+
+export default function CookieConsent(): ReactElement | null {
+  const [visible, setVisible] = useState<boolean>(false);
 
   useEffect(() => {
     try {
@@ -19,23 +21,17 @@ export default function CookieConsent() {
     }
   }, []);
 
-  const handleAccept = () => {
+  const setConsent = (value: ConsentValue): void => {
     try {
-      localStorage.setItem(COOKIE_KEY, 'accepted');
+      localStorage.setItem(COOKIE_KEY, value);
     } catch (e) {
       // Ignore if localStorage is disabled
     }
     setVisible(false);
   };
 
-  const handleReject = () => {
-    try {
-      localStorage.setItem(COOKIE_KEY, 'rejected');
-    } catch (e) {
-      // Ignore if localStorage is disabled
-    }
-    setVisible(false);
-  };
+  const handleAccept = (): void => setConsent('accepted');
+  const handleReject = (): void => setConsent('rejected');
 
   if (!visible) return null;
 


### PR DESCRIPTION
## Summary
Converts `CookieConsent.jsx` to TypeScript (`CookieConsent.tsx`) with strict typing, per #744.

## Changes
- Renamed `src/components/CookieConsent.jsx` → `src/components/CookieConsent.tsx` (via `git mv` to preserve history)
- Added explicit `useState<boolean>` generic for the `visible` state
- Introduced a `ConsentValue = 'accepted' | 'rejected'` union type, and consolidated the near-duplicate `handleAccept`/`handleReject` bodies into a single typed `setConsent(value: ConsentValue)` helper
- Added explicit `ReactElement | null` return type on the component (used React's `ReactElement` type instead of the global `JSX.Element`, since the global `JSX` namespace changed in React 19's type definitions)
- No props interface was needed — component takes no props (verified via its only usage, `<CookieConsent />` in `src/app/page.tsx`, which requires no import changes since it doesn't reference the file extension)

## Type-check
`npx tsc --noEmit` passes with zero errors on `CookieConsent.tsx`. Note: 4 pre-existing, unrelated errors remain in `src/context/__tests__/AuthContext.test.tsx` — that file was not touched by this PR and is out of scope for this issue.

## How to test
1. `npm run dev`
2. Clear the `cookie_consent` key from localStorage (DevTools → Application → Local Storage)
3. Reload the homepage — banner should appear
4. Click "Accept all" or "Reject non-essential" — banner should hide and localStorage should reflect the choice
5. Reload again — banner should stay hidden

## Related Issue
Closes #744