### PR TITLE
fix(a11y): hide decorative FloatingParticles from screen readers

### DIFF
--- a/src/components/FloatingParticles.tsx
+++ b/src/components/FloatingParticles.tsx
@@ -54,6 +54,7 @@ export function FloatingParticles() {
 
   return (
     <div
+      aria-hidden="true"
       className="fixed inset-0 pointer-events-none overflow-hidden z-0"
       style={{ contain: 'strict' }}
     >


### PR DESCRIPTION
## Summary
Investigated #747 (reduced-motion not respected by `FloatingParticles.tsx`) and found the animation itself is already handled comprehensively:
1. `src/app/globals.css` has a global `@media (prefers-reduced-motion: reduce)` block neutralizing all CSS animations/transitions site-wide
2. `src/app/layout.tsx` wraps the app in `<MotionConfig reducedMotion="user">`, so every framer-motion component (44 files) respects the OS setting automatically
3. `FloatingParticles.tsx` additionally uses `useReducedMotion()` to fully unmount the particle tree rather than just freezing it

Verified with DevTools' reduced-motion emulation: `matchMedia` correctly returns `true` and zero particle elements render.

## Change made
While the motion itself was already handled, the particles' container `<div>` was missing `aria-hidden="true"`. Since these floating symbols are purely decorative with no informational content, they should be excluded from the accessibility tree so screen readers don't traverse them unnecessarily.

## How to test
1. `npm run dev`
2. Inspect the particles container in DevTools — confirm `aria-hidden="true"` is present
3. Visually confirm no change to the animation/appearance (attribute is invisible, screen-reader-only impact)

## Related Issue
Closes #747 
Addresses accessibility follow-up from #747 (motion-reduction itself was already correctly implemented — see investigation notes above)