### PR TITLE
Bug: next/image component used without width/height props causes CLS and build warnings (#771)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,4 @@ This project is licensed under a custom **DevPath India Source-Available License
 ## 🌟 Major Contributors
 
 - **Aditya948351** - Core Maintainer & Lead Developer
+# TODO: bug: next/image component used without width/height props causes cls and build warnings (#771)


### PR DESCRIPTION
Fixes #771