### PR TITLE
feat: add cursor-based pagination to projects showcase

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -11,7 +11,10 @@ import {
   orderBy,
   getDocs,
   limit,
+  startAfter,
   collectionGroup,
+  type QueryDocumentSnapshot,
+  type DocumentData,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import {
@@ -27,7 +30,10 @@ import { getEmbedUrl } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
 import CreateDiscussionModal from '@/components/community/CreateDiscussionModal';
 import ProjectCard from '@/components/projects/ProjectCard';
+import Pagination from '@/components/common/Pagination';
 import DOMPurify from 'dompurify';
+
+const PROJECTS_PAGE_SIZE = 20;
 
 export default function CommunityPage() {
   const { user } = useAuth();
@@ -42,8 +48,15 @@ export default function CommunityPage() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [selectedProject, setSelectedProject] = useState<any>(null);
   const [searchQuery, setSearchQuery] = useState('');
-
-  const fetchData = async () => {
+  // Cursor-based pagination state for the Projects showcase
+  const [pageCursors, setPageCursors] = useState<
+    QueryDocumentSnapshot<DocumentData>[]
+  >([]);
+  const [lastDocInPage, setLastDocInPage] =
+    useState<QueryDocumentSnapshot<DocumentData> | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const fetchData = async (cursor?: QueryDocumentSnapshot<DocumentData>) => {
     setLoading(true);
     try {
       if (activeTab === 'discussions') {
@@ -58,28 +71,27 @@ export default function CommunityPage() {
           snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
         );
       } else {
-        // Fetch Projects for Showcase
-        let q;
-        if (sortOption === 'popular') {
-          // Sort by starCount descending
-          q = query(
-            collection(db, 'projects'),
-            orderBy('starCount', 'desc'),
-            limit(20)
-          );
-        } else {
-          // Sort by createdAt descending (default)
-          q = query(
-            collection(db, 'projects'),
-            orderBy('createdAt', 'desc'),
-            limit(20)
-          );
-        }
+        // Fetch Projects for Showcase, one page at a time.
+        // We ask for PAGE_SIZE + 1 so we can tell whether a next page
+        // exists without firing a second query.
+        const orderField = sortOption === 'popular' ? 'starCount' : 'createdAt';
+        const projectsRef = collection(db, 'projects');
+        const constraints = cursor
+          ? [
+              orderBy(orderField, 'desc'),
+              startAfter(cursor),
+              limit(PROJECTS_PAGE_SIZE + 1),
+            ]
+          : [orderBy(orderField, 'desc'), limit(PROJECTS_PAGE_SIZE + 1)];
 
+        const q = query(projectsRef, ...constraints);
         const snapshot = await getDocs(q);
-        setProjects(
-          snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
-        );
+        const docs = snapshot.docs;
+        const pageDocs = docs.slice(0, PROJECTS_PAGE_SIZE);
+
+        setProjects(pageDocs.map((doc) => ({ id: doc.id, ...doc.data() })));
+        setHasNextPage(docs.length > PROJECTS_PAGE_SIZE);
+        setLastDocInPage(pageDocs[pageDocs.length - 1] ?? null);
       }
     } catch (error: any) {
       console.error('Error fetching data:', error);
@@ -93,8 +105,29 @@ export default function CommunityPage() {
     }
   };
 
+  const handleNextPage = () => {
+    if (!hasNextPage || !lastDocInPage) return;
+    setPageCursors((prev) => [...prev, lastDocInPage]);
+    setCurrentPage((page) => page + 1);
+    fetchData(lastDocInPage);
+  };
+
+  const handlePreviousPage = () => {
+    if (pageCursors.length === 0) return;
+    const remainingCursors = pageCursors.slice(0, -1);
+    const previousCursor = remainingCursors[remainingCursors.length - 1];
+    setPageCursors(remainingCursors);
+    setCurrentPage((page) => Math.max(1, page - 1));
+    fetchData(previousCursor);
+  };
+
   useEffect(() => {
+    // Any time the tab or sort option changes, pagination resets to page 1.
+    setPageCursors([]);
+    setLastDocInPage(null);
+    setCurrentPage(1);
     fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab, sortOption]);
 
   const fuse = useMemo(
@@ -276,6 +309,22 @@ export default function CommunityPage() {
             )}
           </div>
         )}
+
+        {/* Pagination only applies to the showcase tab, and only when
+            no client-side search is active (search only covers the
+            currently loaded page of projects). */}
+        {activeTab === 'showcase' &&
+          !searchQuery.trim() &&
+          projects.length > 0 && (
+            <Pagination
+              currentPage={currentPage}
+              hasNextPage={hasNextPage}
+              hasPreviousPage={currentPage > 1}
+              loading={loading}
+              onNext={handleNextPage}
+              onPrevious={handlePreviousPage}
+            />
+          )}
       </div>
 
       {user && (

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  currentPage: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  loading?: boolean;
+  onNext: () => void;
+  onPrevious: () => void;
+}
+
+export default function Pagination({
+  currentPage,
+  hasNextPage,
+  hasPreviousPage,
+  loading = false,
+  onNext,
+  onPrevious,
+}: PaginationProps) {
+  return (
+    <div className="flex items-center justify-center gap-4 mt-8">
+      <button
+        type="button"
+        onClick={onPrevious}
+        disabled={!hasPreviousPage || loading}
+        aria-label="Go to previous page"
+        className="flex items-center gap-1 px-4 py-2 rounded-lg border border-border bg-card text-sm font-medium text-foreground hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-card"
+      >
+        <ChevronLeft size={16} />
+        Previous
+      </button>
+
+      <span className="text-sm text-muted-foreground min-w-[80px] text-center">
+        Page {currentPage}
+      </span>
+
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={!hasNextPage || loading}
+        aria-label="Go to next page"
+        className="flex items-center gap-1 px-4 py-2 rounded-lg border border-border bg-card text-sm font-medium text-foreground hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-card"
+      >
+        Next
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements #755 — adds a generic `Pagination.tsx` component and Firestore cursor-based pagination (`startAfter`, `limit`) to the Projects Showcase tab on the Community page, so it fetches data one page at a time instead of relying on a single capped query.

## Changes

### New: `src/components/common/Pagination.tsx`
A reusable, presentation-only pagination component:
- `Previous` / `Next` buttons with disabled states when there's no previous/next page
- Current page indicator
- Disables both buttons while a fetch is in progress (`loading` prop)
- No Firestore/data-fetching logic inside — fully decoupled so it can be reused elsewhere in the app

### `src/app/community/page.tsx`
- Replaced the single `limit(20)` query with cursor-based pagination:
  - Fetches `PAGE_SIZE + 1` documents per request so we can detect whether a next page exists without a second query
  - Maintains a `pageCursors` stack of `QueryDocumentSnapshot`s, so "Previous" can navigate backward without needing Firestore's (nonexistent) native backward cursor
  - `startAfter(cursor)` is used for "Next"; popping the cursor stack and re-fetching handles "Previous"
- Pagination automatically resets to page 1 whenever the tab or sort option (`Newest`/`Popular`) changes
- Rendered the new `<Pagination>` component below the projects grid, visible only on the Showcase tab

## Known limitation (pre-existing, not introduced by this PR)
Client-side search (Fuse.js) only searches within the currently loaded page of projects, since it operates on the fetched `projects` array rather than the full Firestore collection. This was already the case before this change — pagination doesn't make it worse, but it does make it more visible, so the `<Pagination>` controls are hidden while a search query is active to avoid confusion.

## How to test
1. `npm run dev`
2. Go to the Community page → Showcase tab
3. With 20+ projects in Firestore, confirm "Next" is enabled and loads the next page correctly
4. Click "Previous" and confirm it correctly steps back
5. Switch between "Newest" and "Popular" sort — confirm pagination resets to page 1
6. Type in the search box — confirm pagination controls hide, since search is scoped to the loaded page only

Verified locally with 25 seeded test projects — pagination correctly showed page 1 (20 projects) → clicked Next → showed remaining 5 (page 2, Next disabled) → clicked Previous → returned to page 1. Sort toggling correctly reset pagination to page 1.

## Related Issue
Closes #755