### PR TITLE
feat: add reusable ProjectCardSkeleton loader

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -27,6 +27,7 @@ import { getEmbedUrl } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
 import CreateDiscussionModal from '@/components/community/CreateDiscussionModal';
 import ProjectCard from '@/components/projects/ProjectCard';
+import ProjectCardSkeleton from '@/components/projects/ProjectCardSkeleton';
 import DOMPurify from 'dompurify';
 
 export default function CommunityPage() {
@@ -208,9 +209,17 @@ export default function CommunityPage() {
 
         {/* Content */}
         {loading ? (
-          <div className="flex justify-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
-          </div>
+          activeTab === 'showcase' ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <ProjectCardSkeleton key={i} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex justify-center py-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
+            </div>
+          )
         ) : (
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
             {activeTab === 'discussions' ? (

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -39,6 +39,7 @@ import styles from './Profile.module.css';
 import 'github-markdown-css/github-markdown.css';
 import ProjectUploadModal from '@/components/projects/ProjectUploadModal';
 import ProjectCard from '@/components/projects/ProjectCard';
+import ProjectCardSkeleton from '@/components/projects/ProjectCardSkeleton';
 import Achievements from '@/components/profile/Achievements';
 import Rewards from '@/components/profile/Rewards';
 import DevCard from '@/components/profile/DevCard';
@@ -971,19 +972,7 @@ export default function UserProfile() {
                 aria-label="Loading projects"
               >
                 {Array.from({ length: 4 }).map((_, i) => (
-                  <div
-                    key={i}
-                    className="rounded-xl border border-border/50 bg-muted/20 p-5 animate-pulse"
-                  >
-                    <div className="h-40 w-full rounded-lg bg-muted/40 mb-4" />
-                    <div className="h-5 w-3/4 rounded bg-muted/40 mb-2" />
-                    <div className="h-3 w-full rounded bg-muted/30 mb-1" />
-                    <div className="h-3 w-5/6 rounded bg-muted/30 mb-4" />
-                    <div className="flex gap-2">
-                      <div className="h-5 w-16 rounded-full bg-muted/30" />
-                      <div className="h-5 w-16 rounded-full bg-muted/30" />
-                    </div>
-                  </div>
+                  <ProjectCardSkeleton key={i} />
                 ))}
               </div>
             ) : projects.length === 0 ? (

--- a/src/components/projects/ProjectCardSkeleton.tsx
+++ b/src/components/projects/ProjectCardSkeleton.tsx
@@ -1,0 +1,42 @@
+export default function ProjectCardSkeleton() {
+  return (
+    <div
+      className="bg-card border border-border rounded-xl overflow-hidden shadow-sm flex flex-col h-full animate-pulse"
+      aria-hidden="true"
+    >
+      {/* Thumbnail / video area */}
+      <div className="aspect-video bg-muted" />
+
+      <div className="p-5 flex flex-col flex-grow">
+        {/* Title row */}
+        <div className="flex justify-between items-start mb-2 gap-2">
+          <div className="h-5 bg-muted rounded w-2/3" />
+          <div className="h-5 w-5 bg-muted rounded-full shrink-0" />
+        </div>
+
+        {/* Author + star row */}
+        <div className="flex justify-between items-center mb-3">
+          <div className="h-3 w-24 bg-muted rounded" />
+          <div className="h-5 w-12 bg-muted rounded-full" />
+        </div>
+
+        {/* Skills row */}
+        <div className="flex flex-wrap gap-1.5 mb-4">
+          <div className="h-4 w-14 bg-muted rounded-full" />
+          <div className="h-4 w-14 bg-muted rounded-full" />
+          <div className="h-4 w-10 bg-muted rounded-full" />
+        </div>
+
+        {/* Description lines */}
+        <div className="space-y-2 mb-4">
+          <div className="h-3 bg-muted rounded w-full" />
+          <div className="h-3 bg-muted rounded w-full" />
+          <div className="h-3 bg-muted rounded w-2/3" />
+        </div>
+
+        {/* "Read More" placeholder */}
+        <div className="h-3 w-16 bg-muted rounded mt-auto" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements #748 — creates a reusable `ProjectCardSkeleton` component using Tailwind's `animate-pulse`, matching `ProjectCard.tsx`'s actual layout (thumbnail, title, author/star row, skills pills, description lines, "Read More" placeholder).

## Findings
`ProjectCard` is used in 2 places that fetch data:
1. `UserProfile.tsx` — already had a skeleton, but it was hand-rolled inline and didn't closely match `ProjectCard`'s real shape
2. `community/page.tsx` (Showcase tab) — had **no** skeleton at all, just a plain spinner, meaning the grid area was effectively blank/re-flowing while data loaded (the exact problem described in the issue)

## Changes
- **New:** `src/components/projects/ProjectCardSkeleton.tsx` — a single, reusable, presentation-only skeleton component
- **`UserProfile.tsx`** — replaced the inline duplicate skeleton markup with `<ProjectCardSkeleton />`, removing duplication
- **`community/page.tsx`** — the Showcase tab now renders a grid of `ProjectCardSkeleton`s while loading, instead of a generic spinner; the Discussions tab keeps its existing spinner (different content shape, not addressed by this component)

## How to test
1. `npm run dev`
2. Visit your profile page and refresh — confirm skeleton project cards show briefly before real data
3. Visit Community → Showcase tab and refresh — confirm skeleton cards appear instead of a blank grid + spinner
4. Visit Community → Discussions tab and refresh — confirm the spinner is unchanged there

## Related Issue
Closes #748