### PR TITLE
fix: 3 bare excepts should catch ValueError instead of BaseException

### DIFF
--- a/scripts/extract_rankings.py
+++ b/scripts/extract_rankings.py
@@ -64,7 +64,7 @@ def extract_rankings():
                 # Check if Rank is numeric, if not skip (it might be a comment row)
                 try:
                     rank = int(rank_val)
-                except:
+                except ValueError:
                     continue
                 
                 item = {

--- a/scripts/extract_rankings_v2.py
+++ b/scripts/extract_rankings_v2.py
@@ -18,7 +18,7 @@ def safe_float(val):
         if match:
             try:
                 return float(match.group(1))
-            except:
+            except ValueError:
                 pass
         return 0.0
 
@@ -96,7 +96,7 @@ def extract_rankings():
                 
                 try:
                     rank = int(rank_val)
-                except:
+                except ValueError:
                     continue
                 
                 if i == 0:


### PR DESCRIPTION
Real bugs: 3 bare 'except:' in extract_rankings.py and extract_rankings_v2.py catch BaseException (KeyboardInterrupt, SystemExit). Changed to except ValueError since only int()/float() conversion is expected.