### PR TITLE
fix: replace innerHTML with textContent and fix NotificationDropdown spread order

### DIFF
--- a/scripts/extract_rankings.py
+++ b/scripts/extract_rankings.py
@@ -64,7 +64,7 @@ def extract_rankings():
                 # Check if Rank is numeric, if not skip (it might be a comment row)
                 try:
                     rank = int(rank_val)
-                except:
+                except ValueError:
                     continue
                 
                 item = {

--- a/scripts/extract_rankings_v2.py
+++ b/scripts/extract_rankings_v2.py
@@ -18,7 +18,7 @@ def safe_float(val):
         if match:
             try:
                 return float(match.group(1))
-            except:
+            except ValueError:
                 pass
         return 0.0
 
@@ -96,7 +96,7 @@ def extract_rankings():
                 
                 try:
                     rank = int(rank_val)
-                except:
+                except ValueError:
                     continue
                 
                 if i == 0:

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -69,17 +69,17 @@ export default function WikiPage() {
 
             const button = document.createElement('button');
             button.className = 'absolute right-3 top-3 px-2 py-1 text-xs font-semibold bg-zinc-900/80 text-zinc-300 rounded border border-white/10 opacity-0 group-hover:opacity-100 hover:bg-zinc-800 hover:text-white transition-all duration-200 shadow-md cursor-pointer backdrop-blur-sm';
-            button.innerHTML = 'Copy';
+            button.textContent = 'Copy';
             button.type = 'button';
 
             button.addEventListener('click', async () => {
                 const codeText = pre.textContent || '';
                 try {
                     await navigator.clipboard.writeText(codeText);
-                    button.innerHTML = 'Copied!';
+                    button.textContent = 'Copied!';
                     button.className = 'absolute right-3 top-3 px-2 py-1 text-xs font-semibold bg-emerald-600 text-white rounded border border-emerald-500 transition-all duration-200 shadow-md';
                     setTimeout(() => {
-                        button.innerHTML = 'Copy';
+                        button.textContent = 'Copy';
                         button.className = 'absolute right-3 top-3 px-2 py-1 text-xs font-semibold bg-zinc-900/80 text-zinc-300 rounded border border-white/10 opacity-0 group-hover:opacity-100 hover:bg-zinc-800 hover:text-white transition-all duration-200 shadow-md cursor-pointer backdrop-blur-sm';
                     }, 2000);
                 } catch (err) {

--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -50,7 +50,7 @@ export function NotificationDropdown() {
 
         const unsubscribe = onSnapshot(q,
             (snapshot) => {
-                setNotifications(snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Notification)));
+                setNotifications(snapshot.docs.map(doc => ({ ...doc.data(), id: doc.id } as Notification)));
             },
             (error) => {
                 console.error("Notification subscription error:", error);


### PR DESCRIPTION
## Fixes

### 1. innerHTML to textContent (wiki/page.tsx)
**Bug:** `button.innerHTML = "Copy"` and `button.innerHTML = "Copied!"` directly manipulate DOM in a React component — this causes hydration mismatches and is an XSS vector even for innocuous text.

**Fix:** Replace innerHTML assignments with textContent, which safely sets text without parsing HTML.

### 2. Notification Spread Override (NotificationDropdown.tsx)
**Bug:** `{ id: doc.id, ...doc.data() }` can silently override the Firestore document `id` if `doc.data()` happens to contain an `id` field (e.g., a user-visible notification ID).

**Fix:** Place `id: doc.id` after the spread so `doc.data()` fields cannot clobber the canonical document identifier.
