### PR TITLE
fix: correct Firestore REST API limit format and fix typo Flesta

### DIFF
--- a/scripts/debug-projects-fetch.js
+++ b/scripts/debug-projects-fetch.js
@@ -26,7 +26,7 @@ async function debugProjects() {
     const query = {
       structuredQuery: {
         from: [{ collectionId: 'projects', allDescendants: true }],
-        limit: 10,
+        limit: { value: 10 },
       },
     };
 

--- a/scripts/mark-hackfiesta-complete.js
+++ b/scripts/mark-hackfiesta-complete.js
@@ -49,7 +49,7 @@ async function main() {
       e.title &&
       (e.title.includes('Hack') ||
         e.title.includes('Fiesta') ||
-        e.title.includes('Flesta'))
+        e.title.includes('Fiesta'))
   );
 
   if (fiesta) {


### PR DESCRIPTION
## Bugs Fixed

1. **scripts/debug-projects-fetch.js**: Fixed limit: 10 to limit: { value: 10 } to match the Firestore REST API structured query specification.

2. **scripts/mark-hackfiesta-complete.js**: Fixed typo Flesta to Fiesta in the event title search string so HackFiesta events are correctly matched.
