### PR TITLE
fix: reorder imports in Hero.tsx - static import before const declaration

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -6,9 +6,9 @@ import Link from 'next/link';
 import Button from '../ui/Button';
 import InteractiveBackground from '../ui/InteractiveBackground';
 import styles from './Hero.module.css';
+import { useEffect, useState, useRef } from 'react';
 
 const LatestEventsHighlight = dynamic(() => import('./LatestEventsHighlight'));
-import { useEffect, useState, useRef } from 'react';
 
 const HeaderScene = dynamic(() => import('@/components/3d/HeaderScene'), {
   ssr: false,


### PR DESCRIPTION
Bugs fixed:
- Hero.tsx had `import` statement after `const` declaration, violating ES module spec
- Moved React import to top of file before all non-import declarations