### PR TITLE
fix: template literal interpolation bugs in GitHub API calls and background

### DIFF
--- a/src/components/ui/InteractiveBackground.tsx
+++ b/src/components/ui/InteractiveBackground.tsx
@@ -56,7 +56,7 @@ const CODE_LINES = [
   'pip install knowledge',
   'docker build -t devpath .',
   'kubectl apply -f community.yaml',
-  'curl -X POST ${DEVPATH_API}/join',
+  `curl -X POST ${DEVPATH_API}/join`,
   'chmod +x ./your_potential.sh',
   './launch_career.sh --mode=open-source',
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -5,7 +5,7 @@ const DEVPATH_REPO =
   'devpathindcommunity-india/DevPath-Web';
 const PER_PAGE = process.env.NEXT_PUBLIC_GITHUB_PER_PAGE ?? '100';
 export const fetchUserProfile = async (token: string) => {
-  const res = await fetch('${GITHUB_API}/user', {
+  const res = await fetch(`${GITHUB_API}/user`, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.github.v3+json',
@@ -17,7 +17,7 @@ export const fetchUserProfile = async (token: string) => {
 
 export const fetchUserRepos = async (token: string) => {
   const res = await fetch(
-    '${GITHUB_API}/user/repos?sort=updated&per_page=${PER_PAGE}&type=all',
+    `${GITHUB_API}/user/repos?sort=updated&per_page=${PER_PAGE}&type=all`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -76,7 +76,7 @@ export const fetchRepoContributorStats = async (token?: string) => {
     }
 
     let res = await fetch(
-      '${GITHUB_API}/repos/${DEVPATH_REPO}/stats/contributors',
+      `${GITHUB_API}/repos/${DEVPATH_REPO}/stats/contributors`,
       { headers }
     );
 
@@ -85,7 +85,7 @@ export const fetchRepoContributorStats = async (token?: string) => {
     while (res.status === 202 && retries < 3) {
       await new Promise((resolve) => setTimeout(resolve, 1500));
       res = await fetch(
-        '${GITHUB_API}/repos/${DEVPATH_REPO}/stats/contributors',
+        `${GITHUB_API}/repos/${DEVPATH_REPO}/stats/contributors`,
         { headers }
       );
       retries++;


### PR DESCRIPTION
## Bug Fixes

1. **github.ts** — 4 GitHub API endpoint URLs used single quotes instead of template literals (backticks), causing `${GITHUB_API}` and `${DEVPATH_REPO}` to render literally instead of interpolating the actual values. This broke `fetchUserProfile`, `fetchUserRepos`, and `fetchRepoContributorStats` at runtime.

2. **InteractiveBackground.tsx** — `${DEVPATH_API}` in the code snippets array was not being interpolated due to single quotes, showing the literal string on screen instead of the configured API URL.