### PR TITLE
fix: import order violation in ESM modules and untyped API response

### DIFF
--- a/src/components/home/CodingNews.tsx
+++ b/src/components/home/CodingNews.tsx
@@ -105,7 +105,13 @@ export default function CodingNews() {
         throw new Error('Failed to fetch news');
       }
       const data = await response.json();
-      setNews(data);
+      if (Array.isArray(data)) {
+        setNews(data as NewsItem[]);
+      } else if (data && Array.isArray(data.articles)) {
+        setNews(data.articles as NewsItem[]);
+      } else {
+        setNews(FALLBACK_NEWS);
+      }
     } catch (err) {
       console.error('Error fetching news:', err);
       // Fall back gracefully even if fetch fails

--- a/src/components/ui/InteractiveBackground.tsx
+++ b/src/components/ui/InteractiveBackground.tsx
@@ -1,8 +1,9 @@
 'use client';
-const DEVPATH_API =
-  process.env.NEXT_PUBLIC_DEVPATH_API_URL ?? 'https://api.devpath.in';
 import { useEffect, useRef } from 'react';
 import { useUIStore } from '@/stores/ui-store';
+
+const DEVPATH_API =
+  process.env.NEXT_PUBLIC_DEVPATH_API_URL ?? 'https://api.devpath.in';
 
 // Code snippets that type across the screen — dev/community themed
 const CODE_LINES = [

--- a/src/context/RealTimeContext.tsx
+++ b/src/context/RealTimeContext.tsx
@@ -1,8 +1,9 @@
 'use client';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
 const AVATAR_API =
   process.env.NEXT_PUBLIC_AVATAR_API_URL ??
   'https://api.dicebear.com/7.x/avataaars/svg';
-import React, { createContext, useContext, useState, useEffect } from 'react';
 
 interface Activity {
   id: number;


### PR DESCRIPTION
**Bugs fixed:**

1. **ESM import order violation (RealTimeContext.tsx)**: `AVATAR_API` constant declared before `import` statement — invalid ESM syntax that can break strict build tools.

2. **ESM import order violation (InteractiveBackground.tsx)**: Same pattern — `DEVPATH_API` constant declared before imports.

3. **Untyped API response (CodingNews.tsx)**: `setNews(data)` accepted arbitrary JSON without validating it matches `NewsItem[]`. Added array check with graceful fallback to `FALLBACK_NEWS`.

Verification:
- No more import-before-code lint/compile errors
- News API responses validated before setting state
- Fallback news shown gracefully on API format mismatch